### PR TITLE
feat: patch `UserEnvironmentProvider.GetCurrentNetworkType`. Force `NetworkType.Internet`.

### DIFF
--- a/ISTA-Patcher/Core/PatchUtils.cs
+++ b/ISTA-Patcher/Core/PatchUtils.cs
@@ -430,6 +430,11 @@ internal static partial class PatchUtils
             "GetCurrentUserEnvironment",
             "()BMW.Rheingold.PresentationFramework.Authentication.UserEnvironment",
             DnlibUtils.ReturnUInt32Method(2)
+        ) + module.PatchFunction(
+            "BMW.Rheingold.PresentationFramework.Authentication.UserEnvironmentProvider",
+            "GetCurrentNetworkType",
+            "()BMW.Rheingold.PresentationFramework.Authentication.NetworkType",
+            DnlibUtils.ReturnUInt32Method(1)
         );
     }
 


### PR DESCRIPTION
NetworkType enum is comprised of `Intranet` and `Internet` values. Value `1` coresponds to `Internet`.
Closes #14 