### PR TITLE
feat: support GetCurrentUserEnvironment & GetCurrentNetworkType in BMW.ISPI.TRIC.ISTA.LOGIN.dll

### DIFF
--- a/src/ISTA-Patcher/Assets/appsettings.json
+++ b/src/ISTA-Patcher/Assets/appsettings.json
@@ -5,6 +5,7 @@
         "!PSdZ/host/PsdzServiceImpl.dll",
         "!PSdZ/hostx64/PsdzServiceImpl.dll",
         "Authoring.dll",
+	"\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.dll",
         "CommonServices.dll",
         "FscValidationClient.dll",
         "ISTAGUI.exe",

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -283,7 +283,7 @@ public static partial class PatchUtils
     [UserAuthPatch]
     [LibraryName("RheingoldPresentationFramework.dll")]
     [FromVersion("4.44")]
-    [UntilVersion("4.52")]
+    [UntilVersion("4.51")]
     public static int PatchUserEnvironmentProvider(ModuleDefMD module)
     {
         return module.PatchFunction(
@@ -295,6 +295,24 @@ public static partial class PatchUtils
             "\u0042\u004d\u0057.Rheingold.PresentationFramework.Authentication.UserEnvironmentProvider",
             "GetCurrentNetworkType",
             "()\u0042\u004d\u0057.Rheingold.PresentationFramework.Authentication.NetworkType",
+            DnlibUtils.ReturnUInt32Method(1) // LAN
+        );
+    }
+
+    [UserAuthPatch]
+    [LibraryName("\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.dll")]
+    [FromVersion("4.52")]
+    public static int PatchLoginUserEnvironmentProvider(ModuleDefMD module)
+    {
+        return module.PatchFunction(
+            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
+            "GetCurrentUserEnvironment",
+            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.LoginRepository.Entities.UserEnvironment",
+            DnlibUtils.ReturnUInt32Method(2) // PROD
+        ) + module.PatchFunction(
+            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
+            "GetCurrentNetworkType",
+            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.LoginRepository.Entities.NetworkType",
             DnlibUtils.ReturnUInt32Method(1) // LAN
         );
     }

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -283,7 +283,7 @@ public static partial class PatchUtils
     [UserAuthPatch]
     [LibraryName("RheingoldPresentationFramework.dll")]
     [FromVersion("4.44")]
-    [UntilVersion("4.51")]
+    [UntilVersion("4.52")]
     public static int PatchUserEnvironmentProvider(ModuleDefMD module)
     {
         return module.PatchFunction(


### PR DESCRIPTION
Addressing https://github.com/tautcony/ISTA-Patcher/issues/53

I tried to update the code to handle 4.52... Hope it is fine.

I'm not sure about "[UntilVersion("4.51")]" regarding old DLL..
Maybe I should have left 4.52...

I still have the warning...

![image](https://github.com/user-attachments/assets/6befa34c-2382-4dbb-9664-ef92242d0373)
![image](https://github.com/user-attachments/assets/9def9e65-658d-4991-9824-b4daf8dd1516)

