### PR TITLE
fix: verify patch was actually applied by comparing IL body fingerprint

### DIFF
--- a/src/ISTAlter/Core/PatchUtils.Base.cs
+++ b/src/ISTAlter/Core/PatchUtils.Base.cs
@@ -125,6 +125,8 @@ public static partial class PatchUtils
                 case Instruction target:
                     hash.Add(body.Instructions.IndexOf(target));
                     break;
+                default:
+                    break;
             }
         }
 

--- a/src/ISTAlter/Core/PatchUtils.Base.cs
+++ b/src/ISTAlter/Core/PatchUtils.Base.cs
@@ -91,10 +91,50 @@ public static partial class PatchUtils
         }
     }
 
+    private static int ComputeBodyFingerprint(MethodDef method)
+    {
+        if (method.Body is not { } body)
+        {
+            return 0;
+        }
+
+        HashCode hash = default;
+        foreach (var instr in body.Instructions)
+        {
+            hash.Add(instr.OpCode.Code);
+            switch (instr.Operand)
+            {
+                case string s:
+                    hash.Add(s.GetHashCode(StringComparison.Ordinal));
+                    break;
+                case int i:
+                    hash.Add(i);
+                    break;
+                case long l:
+                    hash.Add(l);
+                    break;
+                case double d:
+                    hash.Add(d.GetHashCode());
+                    break;
+                case float f:
+                    hash.Add(f.GetHashCode());
+                    break;
+                case IFullName fn:
+                    hash.Add(fn.FullName.GetHashCode(StringComparison.Ordinal));
+                    break;
+                case Instruction target:
+                    hash.Add(body.Instructions.IndexOf(target));
+                    break;
+            }
+        }
+
+        return hash.ToHashCode();
+    }
+
     /// <summary>
     /// Applies a patch to a method in the specified assembly.
     /// </summary>
-    /// <param name="module">The <see cref="dnlib.DotNet.ModuleDefMD"/> to apply the patch to.</param>
+    /// <param name="module">The <see cref="ModuleDefMD"/> to apply the patch to.</param>
     /// <param name="type">The full name of the type containing the method.</param>
     /// <param name="name">The name of the method.</param>
     /// <param name="desc">The description of the method.</param>
@@ -116,14 +156,15 @@ public static partial class PatchUtils
             return 0;
         }
 
+        var fingerprint = ComputeBodyFingerprint(method);
         operation(method);
-        return 1;
+        return ComputeBodyFingerprint(method) != fingerprint ? 1 : 0;
     }
 
     /// <summary>
     /// Applies a patch to an async method in the specified assembly.
     /// </summary>
-    /// <param name="module">The <see cref="dnlib.DotNet.ModuleDefMD"/> to apply the patch to.</param>
+    /// <param name="module">The <see cref="ModuleDefMD"/> to apply the patch to.</param>
     /// <param name="type">The full name of the type containing the method.</param>
     /// <param name="name">The name of the method.</param>
     /// <param name="desc">The description of the method.</param>
@@ -159,14 +200,15 @@ public static partial class PatchUtils
             return 0;
         }
 
+        var fingerprint = ComputeBodyFingerprint(generateMethod);
         operation(generateMethod);
-        return 1;
+        return ComputeBodyFingerprint(generateMethod) != fingerprint ? 1 : 0;
     }
 
     /// <summary>
     /// Applies a patch to a property getter in the specified assembly.
     /// </summary>
-    /// <param name="module">The <see cref="dnlib.DotNet.ModuleDefMD"/> to apply the patch to.</param>
+    /// <param name="module">The <see cref="ModuleDefMD"/> to apply the patch to.</param>
     /// <param name="type">The full name of the type containing the method.</param>
     /// <param name="propertyName">The name of the property.</param>
     /// <param name="operation">The action representing the patch operation to be applied to the method.</param>
@@ -193,8 +235,10 @@ public static partial class PatchUtils
 
         Log.Verbose("Applying patch {PatchName} => {Name} <= {Module}: {Result}", memberName, $"{propertyName}::getter", module, propertyDef.GetMethod != null);
 
-        operation(propertyDef.GetMethod);
-        return 1;
+        var getter = propertyDef.GetMethod;
+        var fingerprint = ComputeBodyFingerprint(getter);
+        operation(getter);
+        return ComputeBodyFingerprint(getter) != fingerprint ? 1 : 0;
     }
 
     /// <summary>


### PR DESCRIPTION
fix: verify patch was actually applied by comparing IL body fingerprint

Currently, PatchFunction, PatchAsyncFunction and PatchGetter return 1 as soon as the target method is found, regardless of whether the Action<MethodDef> operation actually modified anything. When an operation fails internally — for example, a required instruction or operand is not found and the method returns early after a Log.Warning — the method body is left unchanged but the patch count still reports 1. This makes the final indicator misleading: a patch can show [SomePatch: 1] while having done nothing.

Fix

Add a private ComputeBodyFingerprint helper that produces a lightweight hash of the method body by combining opcode codes and key operand types (string constants, integer/long/float/double values, IFullName.FullName for method and field references, and branch target indices). The fingerprint is computed before and after the operation; the function returns 1 only if the fingerprint changed, 0 otherwise.

This covers all real-world modification patterns:

instructions added or removed (count and positions shift)
opcode replacement (ldc.i4.0 → ldc.i4.1, brfalse → nop, etc.)
operand replacement (string constant, method/field reference)
branch target displacement (index of target instruction changes)
Properties

Zero API changes — all existing callers are unaffected
No behavioral change for patches that already work correctly; they will still return 1
Patches that silently failed before will now correctly return 0, making the log indicator accurate
Negligible performance impact: O(n) on instruction count, called once per method per file in a one-shot tool