### PR TITLE
perf: make ComputeBodyFingerprint O(n) via instruction index map

### DIFF
--- a/src/ISTAlter/Core/PatchUtils.Base.cs
+++ b/src/ISTAlter/Core/PatchUtils.Base.cs
@@ -99,6 +99,12 @@ public static partial class PatchUtils
         }
 
         HashCode hash = default;
+        var indexMap = new Dictionary<Instruction, int>(body.Instructions.Count);
+        for (var idx = 0; idx < body.Instructions.Count; idx++)
+        {
+            indexMap[body.Instructions[idx]] = idx;
+        }
+
         foreach (var instr in body.Instructions)
         {
             hash.Add(instr.OpCode.Code);
@@ -123,7 +129,7 @@ public static partial class PatchUtils
                     hash.Add(fn.FullName.GetHashCode(StringComparison.Ordinal));
                     break;
                 case Instruction target:
-                    hash.Add(body.Instructions.IndexOf(target));
+                    hash.Add(indexMap.TryGetValue(target, out var targetIndex) ? targetIndex : -1);
                     break;
                 default:
                     break;


### PR DESCRIPTION
Replace per-branch body.Instructions.IndexOf(target) (O(n) scan, O(n^2) overall) with a one-time Dictionary<Instruction,int> lookup, restoring the O(n) complexity claimed in the patch-verification design.