### PR TITLE
fix/refactor: improve patch versioning, dispatch, and result observability

### DIFF
--- a/src/ISTAlter/Core/Patch.cs
+++ b/src/ISTAlter/Core/Patch.cs
@@ -53,11 +53,17 @@ public static partial class Patch
         var attemptedCount = attemptedPatches.Count;
         var skippedCount = patcherProvider.Patches.Count - attemptedCount;
         var totalFunctions = patcherProvider.Patches.Sum(p => p.AppliedCount);
+
+        const string green = "[32m";
+        const string red = "[31m";
+        const string reset = "[0m";
+        var countColor = appliedCount == attemptedCount ? green : red;
+        var counter = $"{countColor}{appliedCount}/{attemptedCount}{reset}";
+
         Log.Information(
-            @"=== ISTA Patch Done in {Time:mm\:ss\.fff} [{Applied}/{Attempted} patches, {Functions} functions, {Skipped} skipped] ===",
+            @"=== ISTA Patch Done in {Time:mm\:ss\.fff} [{Counter} patches, {Functions} functions, {Skipped} skipped] ===",
             timer.Elapsed,
-            appliedCount,
-            attemptedCount,
+            counter,
             totalFunctions,
             skippedCount);
     }

--- a/src/ISTAlter/Core/Patch.cs
+++ b/src/ISTAlter/Core/Patch.cs
@@ -143,6 +143,12 @@ public static partial class Patch
                     continue;
                 }
 
+                if (!PatchUtils.IsVersionInRange(module, patch.Method))
+                {
+                    resultBuilder.Append('-');
+                    continue;
+                }
+
                 if (!PatchUtils.IsPatchApplicable(module, patch.Method))
                 {
                     resultBuilder.Append('-');

--- a/src/ISTAlter/Core/Patch.cs
+++ b/src/ISTAlter/Core/Patch.cs
@@ -47,7 +47,19 @@ public static partial class Patch
         }
 
         timer.Stop();
-        Log.Information(@"=== ISTA Patch Done in {Time:mm\:ss\.fff} ===", timer.Elapsed);
+
+        var attemptedPatches = patcherProvider.Patches.Where(p => p.AttemptedCount > 0).ToList();
+        var appliedCount = attemptedPatches.Count(p => p.AppliedCount > 0);
+        var attemptedCount = attemptedPatches.Count;
+        var skippedCount = patcherProvider.Patches.Count - attemptedCount;
+        var totalFunctions = patcherProvider.Patches.Sum(p => p.AppliedCount);
+        Log.Information(
+            @"=== ISTA Patch Done in {Time:mm\:ss\.fff} [{Applied}/{Attempted} patches, {Functions} functions, {Skipped} skipped] ===",
+            timer.Elapsed,
+            appliedCount,
+            attemptedCount,
+            totalFunctions,
+            skippedCount);
     }
 
     private static void PatchSingleFile(string pendingPatchItem, string guiBasePath, int indentLength, IPatcherProvider patcherProvider, ISTAOptions.PatchOptions options)
@@ -155,6 +167,7 @@ public static partial class Patch
                     continue;
                 }
 
+                patch.AddAttemptedCount();
                 var patchedCount = patch.Delegator(module);
                 patch.AddAppliedCount(patchedCount);
                 if (patchedCount > 0)
@@ -244,14 +257,15 @@ public static partial class Patch
     private static IEnumerable<string> BuildIndicator(List<PatchInfo> patches)
     {
         return patches
-               .Select(p => (Name: FormatName(p.Method), Count: p.AppliedCount))
+               .Select(p => (Name: FormatName(p.Method), Count: p.AppliedCount, Attempted: p.AttemptedCount))
                .Reverse()
                .Select((item, idx) =>
                {
                    var revIdx = patches.Count - 1 - idx;
                    var verticalBars = new string('│', revIdx);
                    var horizontalBars = new string('─', idx);
-                   return $"{verticalBars}└{horizontalBars}>[{item.Name}: {item.Count}]";
+                   var label = item.Attempted == 0 ? "skip" : item.Count.ToString();
+                   return $"{verticalBars}└{horizontalBars}>[{item.Name}: {label}]";
                });
 
         string FormatName(MethodInfo method)

--- a/src/ISTAlter/Core/PatchUtils.Base.cs
+++ b/src/ISTAlter/Core/PatchUtils.Base.cs
@@ -414,6 +414,40 @@ public static partial class PatchUtils
     /// <param name="module">Module to check.</param>
     /// <param name="patcher">Patcher to check.</param>
     /// <returns>True if the patcher is applicable.</returns>
+    /// <summary>
+    /// Returns true when the module's assembly version falls within the patch's declared
+    /// [FromVersion, UntilVersion) range.  A missing bound is treated as open-ended.
+    /// This check is intentionally silent: being outside the declared range is expected
+    /// behaviour, not an error condition.
+    /// </summary>
+    public static bool IsVersionInRange(ModuleDefMD module, System.Reflection.MethodInfo? patcher)
+    {
+        var untilVersion = patcher?.GetCustomAttribute<UntilVersionAttribute>()?.Version;
+        var fromVersion = patcher?.GetCustomAttribute<FromVersionAttribute>()?.Version;
+
+        if (fromVersion == null && untilVersion == null)
+        {
+            return true;
+        }
+
+        var moduleVersion = module.Assembly.Version;
+
+        // moduleVersion ∈ [fromVersion, untilVersion)
+        if (fromVersion != null && moduleVersion < fromVersion)
+        {
+            Log.Debug("{PatcherName} not yet applicable for {Assembly}({Version}), requires >= {From}", patcher!.Name, module.Assembly.Name, moduleVersion, fromVersion);
+            return false;
+        }
+
+        if (untilVersion != null && moduleVersion >= untilVersion)
+        {
+            Log.Debug("{PatcherName} no longer applicable for {Assembly}({Version}), requires < {Until}", patcher!.Name, module.Assembly.Name, moduleVersion, untilVersion);
+            return false;
+        }
+
+        return true;
+    }
+
     public static bool IsPatchApplicable(ModuleDefMD module, System.Reflection.MethodInfo? patcher)
     {
         var libraryNames = patcher?.GetCustomAttribute<LibraryNameAttribute>()?.FileName;
@@ -423,44 +457,21 @@ public static partial class PatchUtils
         // Validate attribute dependencies
         if ((untilVersion != null || fromVersion != null) && libraryNames == null)
         {
-            Log.Error("Patcher {PatcherName} has version constraints but no LibraryName attribute", patcher.Name);
+            Log.Error("Patcher {PatcherName} has version constraints but no LibraryName attribute", patcher!.Name);
         }
 
-        // Check library name first
+        // Check library name
         if (libraryNames != null)
         {
             if (!libraryNames.Contains(module.FullName, StringComparer.Ordinal))
             {
-                Log.Debug("{PatcherName} is not valid for library: {Library}", patcher.Name, module.FullName);
+                Log.Debug("{PatcherName} is not valid for library: {Library}", patcher!.Name, module.FullName);
                 return false;
             }
         }
         else
         {
             Log.Debug("Skip library check for {PatchName} due to no library name is set", patcher?.Name);
-        }
-
-        // Then check version
-        if (untilVersion != null || fromVersion != null)
-        {
-            var moduleVersion = module.Assembly.Version;
-
-            // A valid patcher should match the version range: moduleVersion ∈ [fromVersion, untilVersion)
-            if (fromVersion != null && moduleVersion < fromVersion)
-            {
-                Log.Warning("{PatcherName} is not valid for assembly yet: {Assembly}({Version})", patcher.Name, module.Assembly.Name, module.Assembly.Version);
-                return false;
-            }
-
-            if (untilVersion != null && moduleVersion >= untilVersion)
-            {
-                Log.Warning("{PatcherName} is no longer valid for assembly: {Assembly}({Version})", patcher.Name, module.Assembly.Name, module.Assembly.Version);
-                return false;
-            }
-        }
-        else
-        {
-            Log.Debug("No version check for {PatcherName} has been set", patcher?.Name);
         }
 
         return true;

--- a/src/ISTAlter/Core/PatchUtils.Base.cs
+++ b/src/ISTAlter/Core/PatchUtils.Base.cs
@@ -409,17 +409,14 @@ public static partial class PatchUtils
     }
 
     /// <summary>
-    /// Check if the patcher is applicable to the assembly by validating both library name and version.
-    /// </summary>
-    /// <param name="module">Module to check.</param>
-    /// <param name="patcher">Patcher to check.</param>
-    /// <returns>True if the patcher is applicable.</returns>
-    /// <summary>
     /// Returns true when the module's assembly version falls within the patch's declared
     /// [FromVersion, UntilVersion) range.  A missing bound is treated as open-ended.
     /// This check is intentionally silent: being outside the declared range is expected
     /// behaviour, not an error condition.
     /// </summary>
+    /// <param name="module">Module to check.</param>
+    /// <param name="patcher">Patcher to check.</param>
+    /// <returns>True if the module's version is within the declared range (or no range is declared).</returns>
     public static bool IsVersionInRange(ModuleDefMD module, System.Reflection.MethodInfo? patcher)
     {
         var untilVersion = patcher?.GetCustomAttribute<UntilVersionAttribute>()?.Version;
@@ -448,6 +445,13 @@ public static partial class PatchUtils
         return true;
     }
 
+    /// <summary>
+    /// Check if the patcher is applicable to the assembly by validating the declared library name.
+    /// Version-range filtering is handled separately by <see cref="IsVersionInRange"/>.
+    /// </summary>
+    /// <param name="module">Module to check.</param>
+    /// <param name="patcher">Patcher to check.</param>
+    /// <returns>True if the patcher is applicable.</returns>
     public static bool IsPatchApplicable(ModuleDefMD module, System.Reflection.MethodInfo? patcher)
     {
         var libraryNames = patcher?.GetCustomAttribute<LibraryNameAttribute>()?.FileName;

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -307,7 +307,7 @@ public static partial class PatchUtils
     [NotSendPatch]
     [LibraryName("ISTAGUI.exe")]
     [FromVersion("4.55")]
-    public static int PatchMultisessionLogicFrom455(ModuleDefMD module)
+    public static int PatchMultisessionLogicGetters(ModuleDefMD module)
     {
         return module.PatchGetter(
             "\u0042\u004d\u0057.Rheingold.ISTAGUI.Controller.MultisessionLogic",
@@ -537,7 +537,7 @@ public static partial class PatchUtils
     [LibraryName("RheingoldPresentationFramework.dll")]
     [FromVersion("4.44")]
     [UntilVersion("4.52")]
-    public static int PatchUserEnvironmentProviderFrom444(ModuleDefMD module)
+    public static int PatchUserEnvironmentProviderPresentationFramework(ModuleDefMD module)
     {
         return module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.PresentationFramework.Authentication.UserEnvironmentProvider",

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -555,57 +555,38 @@ public static partial class PatchUtils
     [UserAuthPatch]
     [LibraryName("\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.dll")]
     [FromVersion("4.52")]
-    [UntilVersion("4.55")]
-    public static int PatchUserEnvironmentProviderFrom452(ModuleDefMD module)
+    public static int PatchUserEnvironmentProvider(ModuleDefMD module)
     {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
-            "GetCurrentUserEnvironment",
-            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.LoginRepository.Entities.UserEnvironment",
-            DnlibUtils.ReturnUInt32Method(2) // PROD
-        ) + module.PatchFunction(
-            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
-            "GetCurrentNetworkType",
-            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.LoginRepository.Entities.NetworkType",
-            DnlibUtils.ReturnUInt32Method(1) // LAN ?
-        );
-    }
+        const string className = "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider";
 
-    [UserAuthPatch]
-    [LibraryName("\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.dll")]
-    [FromVersion("4.55")]
-    [UntilVersion("4.57")]
-    public static int PatchUserEnvironmentProviderFrom455(ModuleDefMD module)
-    {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
-            "GetCurrentUserEnvironment",
-            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.UserEnvironment",
-            DnlibUtils.ReturnUInt32Method(2) // PROD
-        ) + module.PatchFunction(
-            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
-            "GetCurrentNetworkType",
-            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.NetworkType",
-            DnlibUtils.ReturnUInt32Method(0) // Intranet
-        );
-    }
+        var version = module.Assembly.Version;
+        var result = version < new Version("4.55")
+            ? PatchV452(module)
+            : version < new Version("4.57")
+                ? PatchV455(module)
+                : PatchV457(module);
 
-    [UserAuthPatch]
-    [LibraryName("\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.dll")]
-    [FromVersion("4.57")]
-    public static int PatchUserEnvironmentProviderFrom457(ModuleDefMD module)
-    {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
-            "GetCurrentUserEnvironment",
-            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.UserEnvironment",
-            DnlibUtils.ReturnUInt32Method(2) // PROD
-        ) + module.PatchFunction(
-            "\u0042\u004d\u0057.ISPI.TRIC.ISTA.LOGIN.DataProviders.UserEnvironmentProvider",
-            "GetCurrentNetworkType",
-            "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.EnvironmentNetworkType",
-            DnlibUtils.ReturnUInt32Method(0) // Intranet
-        );
+        if (result == 0)
+        {
+            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchUserEnvironmentProvider), module.Assembly.Name, version);
+        }
+
+        return result;
+
+        // 4.52–4.55: LoginRepository.Entities namespace, NetworkType LAN=1
+        static int PatchV452(ModuleDefMD m) =>
+            m.PatchFunction(className, "GetCurrentUserEnvironment", "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.LoginRepository.Entities.UserEnvironment", DnlibUtils.ReturnUInt32Method(2))
+            + m.PatchFunction(className, "GetCurrentNetworkType", "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.LoginRepository.Entities.NetworkType", DnlibUtils.ReturnUInt32Method(1));
+
+        // 4.55–4.57: Contracts.Enums.UserLogin namespace, Intranet=0
+        static int PatchV455(ModuleDefMD m) =>
+            m.PatchFunction(className, "GetCurrentUserEnvironment", "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.UserEnvironment", DnlibUtils.ReturnUInt32Method(2))
+            + m.PatchFunction(className, "GetCurrentNetworkType", "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.NetworkType", DnlibUtils.ReturnUInt32Method(0));
+
+        // 4.57+: same UserEnvironment, renamed to EnvironmentNetworkType
+        static int PatchV457(ModuleDefMD m) =>
+            m.PatchFunction(className, "GetCurrentUserEnvironment", "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.UserEnvironment", DnlibUtils.ReturnUInt32Method(2))
+            + m.PatchFunction(className, "GetCurrentNetworkType", "()\u0042\u004d\u0057.ISPI.TRIC.ISTA.Contracts.Enums.UserLogin.EnvironmentNetworkType", DnlibUtils.ReturnUInt32Method(0));
     }
 
     [UserAuthPatch]
@@ -801,16 +782,27 @@ public static partial class PatchUtils
     [FixDS2VehicleIdentificationPatch]
     [LibraryName("RheingoldDiagnostics.dll")]
     [FromVersion("4.49")]
-    [UntilVersion("4.56")]
-    public static int PatchFixDS2VehicleIdentFrom449(ModuleDefMD module)
+    public static int PatchFixDS2VehicleIdent(ModuleDefMD module)
     {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.Rheingold.Diagnostics.VehicleIdent",
-            "doVehicleShortTest",
-            "(\u0042\u004d\u0057.Rheingold.CoreFramework.IProgressMonitor)System.Boolean",
-            FixCondition);
+        const string className = "\u0042\u004d\u0057.Rheingold.Diagnostics.VehicleIdent";
+        const string sig = "(\u0042\u004d\u0057.Rheingold.CoreFramework.IProgressMonitor)System.Boolean";
 
-        static void FixCondition(MethodDef method)
+        var version = module.Assembly.Version;
+
+        // < 4.56: camelCase method, HandleMissingEcus(bool) signature, Instruction[] injection
+        // ≥ 4.56: PascalCase method, HandleMissingEcus() signature, List<Instruction> + SimplifyBranches
+        var result = version < new Version("4.56")
+            ? module.PatchFunction(className, "doVehicleShortTest", sig, FixLegacy)
+            : module.PatchFunction(className, "DoVehicleShortTest", sig, FixModern);
+
+        if (result == 0)
+        {
+            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchFixDS2VehicleIdent), module.Assembly.Name, version);
+        }
+
+        return result;
+
+        static void FixLegacy(MethodDef method)
         {
             var instructions = method.Body.Instructions;
 
@@ -861,20 +853,8 @@ public static partial class PatchUtils
                 instructions.Insert(indexOfSetIdentSuccessfully - 2, instruction);
             }
         }
-    }
 
-    [FixDS2VehicleIdentificationPatch]
-    [LibraryName("RheingoldDiagnostics.dll")]
-    [FromVersion("4.56")]
-    public static int PatchFixDS2VehicleIdentFrom456(ModuleDefMD module)
-    {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.Rheingold.Diagnostics.VehicleIdent",
-            "DoVehicleShortTest",
-            "(\u0042\u004d\u0057.Rheingold.CoreFramework.IProgressMonitor)System.Boolean",
-            FixDoVehicleShortTest);
-
-        static void FixDoVehicleShortTest(MethodDef method)
+        static void FixModern(MethodDef method)
         {
             var instructions = method.Body.Instructions;
 
@@ -991,25 +971,33 @@ public static partial class PatchUtils
 
     [MotorbikeClamp15Patch]
     [LibraryName("RheingoldDiagnostics.dll")]
-    [UntilVersion("4.58")]
     public static int PatchMotorbikeClamp15(ModuleDefMD module)
     {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.Rheingold.Diagnostics.VehicleIdent",
-            "ClearAndReadErrorInfoMemory",
-            "(\u0042\u004d\u0057.Rheingold.CoreFramework.Contracts.IJobServices)System.Void",
-            PatchClamp15Check
-        );
+        const string className = "\u0042\u004d\u0057.Rheingold.Diagnostics.VehicleIdent";
+        const string methodName = "ClearAndReadErrorInfoMemory";
+        const string sigLegacy = "(\u0042\u004d\u0057.Rheingold.CoreFramework.Contracts.IJobServices)System.Void";
+        const string sigModern = "(\u0042\u004d\u0057.Rheingold.CoreFramework.Contracts.IJobServices,System.Func`1<System.Collections.Generic.IDictionary`2<System.String,System.Object>>)System.Void";
 
+        var version = module.Assembly.Version;
+        var result = version < new Version("4.58")
+            ? module.PatchFunction(className, methodName, sigLegacy, PatchClamp15Check)
+            : module.PatchFunction(className, methodName, sigModern, PatchClamp15Check);
+
+        if (result == 0)
+        {
+            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchMotorbikeClamp15), module.Assembly.Name, version);
+        }
+
+        return result;
+
+        // IL logic is identical for all versions: redirect the outer HasValue brfalse to skip
+        // the RegisterMessage block when clamp is unavailable.
+        // < 4.58: transforms (!clamp.HasValue || clamp < 0.1) → (clamp.HasValue && clamp < 0.1)
+        // ≥ 4.58: same redirect on restructured control flow
         static void PatchClamp15Check(MethodDef method)
         {
             var instructions = method.Body.Instructions;
 
-            // Transform the logic from:
-            // Original: if (flag && (!clamp.HasValue || clamp < 0.1)) { RegisterMessage(); return; }
-            // To: if (flag && (clamp.HasValue && clamp < 0.1)) { RegisterMessage(); return; }
-
-            // First find the HasValue call
             var hasValueCall = method.FindInstruction(OpCodes.Call, "System.Boolean System.Nullable`1<System.Double>::get_HasValue()");
             if (hasValueCall == null)
             {
@@ -1024,7 +1012,6 @@ public static partial class PatchUtils
                 return;
             }
 
-            // The next instruction after HasValue call should be brfalse.s
             var brfalseInstruction = instructions[hasValueIndex + 1];
             if (brfalseInstruction.OpCode != OpCodes.Brfalse_S)
             {
@@ -1032,8 +1019,6 @@ public static partial class PatchUtils
                 return;
             }
 
-            // Find the instruction that skips the RegisterMessage block (IL_012d in the original)
-            // This should be the target of the second brfalse.s instruction after the value comparison
             var valueComparisonBrfalse = instructions.Skip(hasValueIndex + 2)
                 .FirstOrDefault(inst => inst.OpCode == OpCodes.Brfalse_S);
 
@@ -1043,68 +1028,6 @@ public static partial class PatchUtils
                 return;
             }
 
-            // Change the first brfalse target to point to the same target as the value comparison brfalse
-            // This transforms (!clamp.HasValue || clamp < 0.1) to (clamp.HasValue && clamp < 0.1)
-            brfalseInstruction.Operand = valueComparisonBrfalse.Operand;
-        }
-    }
-
-    [MotorbikeClamp15Patch]
-    [LibraryName("RheingoldDiagnostics.dll")]
-    [FromVersion("4.58")]
-    public static int PatchMotorbikeClamp15From458(ModuleDefMD module)
-    {
-        return module.PatchFunction(
-            "\u0042\u004d\u0057.Rheingold.Diagnostics.VehicleIdent",
-            "ClearAndReadErrorInfoMemory",
-            "(\u0042\u004d\u0057.Rheingold.CoreFramework.Contracts.IJobServices,System.Func`1<System.Collections.Generic.IDictionary`2<System.String,System.Object>>)System.Void",
-            PatchClamp15CheckFrom458
-        );
-
-        static void PatchClamp15CheckFrom458(MethodDef method)
-        {
-            var instructions = method.Body.Instructions;
-
-            // In ISTA 4.58+, the clamp15 check restructured control flow:
-            // if (clamp != null) { if (!(value < 0.1 & hasValue)) { goto IL_12D; } }
-            // RegisterMessage(); return;
-            // IL_12D: (continue)
-            // When HasValue is false, the outer brfalse.s branches forward to RegisterMessage (warning).
-            // Patch: redirect the outer HasValue brfalse.s to IL_12D to suppress the warning
-            // when no clamp15 reading is available, matching the intent of the original patch.
-            var hasValueCall = method.FindInstruction(OpCodes.Call, "System.Boolean System.Nullable`1<System.Double>::get_HasValue()");
-            if (hasValueCall == null)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            var hasValueIndex = instructions.IndexOf(hasValueCall);
-            if (hasValueIndex == -1 || hasValueIndex >= instructions.Count - 1)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            // The next instruction after HasValue call should be brfalse.s (branches to RegisterMessage when null)
-            var brfalseInstruction = instructions[hasValueIndex + 1];
-            if (brfalseInstruction.OpCode != OpCodes.Brfalse_S)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            // Find the inner brfalse.s that skips to IL_12D (branches when !(value < 0.1 & hasValue) is false)
-            var valueComparisonBrfalse = instructions.Skip(hasValueIndex + 2)
-                .FirstOrDefault(inst => inst.OpCode == OpCodes.Brfalse_S);
-
-            if (valueComparisonBrfalse == null)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            // Redirect the outer HasValue brfalse to skip the warning when clamp is unavailable
             brfalseInstruction.Operand = valueComparisonBrfalse.Operand;
         }
     }

--- a/src/ISTAlter/Core/PatchUtils.cs
+++ b/src/ISTAlter/Core/PatchUtils.cs
@@ -157,7 +157,7 @@ public static partial class PatchUtils
     [ValidationPatch]
     [LibraryName("PsdzServiceImpl.dll")]
     [UntilVersion("4.56")]
-    public static int PatchConfigurationServiceTo455(ModuleDefMD module)
+    public static int PatchPsdzConfigurationService(ModuleDefMD module)
     {
         return module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.Psdz.Services.ConfigurationService",

--- a/src/ISTAlter/Core/Patcher/PatchInfo.cs
+++ b/src/ISTAlter/Core/Patcher/PatchInfo.cs
@@ -9,6 +9,7 @@ using dnlib.DotNet;
 public class PatchInfo(Func<ModuleDefMD, int> delegator, MethodInfo method, int appliedCount)
 {
     private int _appliedCount = appliedCount;
+    private int _attemptedCount;
 
     public Func<ModuleDefMD, int> Delegator { get; set; } = delegator;
 
@@ -16,5 +17,10 @@ public class PatchInfo(Func<ModuleDefMD, int> delegator, MethodInfo method, int 
 
     public int AppliedCount => this._appliedCount;
 
+    /// <summary>Number of times the delegator was actually invoked (version and library checks passed).</summary>
+    public int AttemptedCount => this._attemptedCount;
+
     public void AddAppliedCount(int count) => Interlocked.Add(ref this._appliedCount, count);
+
+    public void AddAttemptedCount() => Interlocked.Increment(ref this._attemptedCount);
 }


### PR DESCRIPTION
## Problem

`IsPatchApplicable` mixed three concerns: library filtering, version bounds
checking, and attribute validation. Version range checks emitted `Log.Warning`
for patches legitimately outside their declared bounds, producing misleading
noise on every run:

    [WRN] PatchUserEnvironmentProviderFrom452 is no longer valid for assembly: BMW.ISPI.TRIC.ISTA.LOGIN(4.59.30)
    [WRN] PatchMainWindowViewModel is no longer valid for assembly: ISTAGUI(4.59.30)

Additionally, multiple patch methods existed for the same functional patch
(e.g. `PatchMotorbikeClamp15` + `PatchMotorbikeClamp15From458`), with
version-suffixed names that became meaningless over time and a `0` result
indistinguishable from "tried but broken".

## Changes

### 1. Separate version bounds check from `IsPatchApplicable`

Introduce `IsVersionInRange(ModuleDefMD, MethodInfo?)` as a dedicated silent
pre-filter called before `IsPatchApplicable` in `PatchSingleFile`. Version
bounds are a declared constraint — being outside range is expected behaviour,
not an error.

Call order in `PatchSingleFile` is now unambiguous:
1. `ShouldSkipPatch` — user-supplied library skip list
2. `IsVersionInRange` — declared version bounds (Debug only)
3. `IsPatchApplicable` — library name match (Debug only)
4. `patch.Delegator` — execution (may warn on unexpected IL mismatch)

### 2. Merge version-split patches into single dispatch methods

Replace N separate `[FromVersion]`/`[UntilVersion]` methods per functional
patch with a single public method dispatching internally via a version switch
and local static functions. Each merged method emits an explicit `Log.Warning`
when in-range but no target matches — making regressions on new ISTA releases
immediately visible instead of silent zeros.

Merged groups:
- `PatchMotorbikeClamp15` + `PatchMotorbikeClamp15From458` → `PatchMotorbikeClamp15`
  (identical IL logic, version selects the method signature)
- `PatchFixDS2VehicleIdentFrom449` + `PatchFixDS2VehicleIdentFrom456` → `PatchFixDS2VehicleIdent`
- `PatchUserEnvironmentProviderFrom452/455/457` → `PatchUserEnvironmentProvider`

### 3. Patch result clarity and observability

- Add `AttemptedCount` to `PatchInfo`, incremented only when the delegator is
  actually invoked (version and library checks passed)
- Patches never attempted display `skip` in the indicator tree instead of `0`
- Done line now shows `[X/Y patches, Z functions, N skipped]` where Y counts
  only attempted patches; counter is green when all attempted patches succeeded,
  red when at least one returned 0
- Rename version-suffixed methods to reflect their actual target:
  - `PatchUserEnvironmentProviderFrom444` → `PatchUserEnvironmentProviderPresentationFramework`
  - `PatchMultisessionLogicFrom455` → `PatchMultisessionLogicGetters`
  - `PatchConfigurationServiceTo455` → `PatchPsdzConfigurationService`

## Behaviour change

- Version-bounded patches silently skipped when out of range (was: `Log.Warning`)
- Patches skipped by design show `skip`; patches tried but returning `0` show `0`
- New `Log.Warning` when an in-range patch finds no applicable target (regression detection)
- −4 entries in the patch list (merged groups), no functional change to patch results

<img width="1327" height="795" alt="image" src="https://github.com/user-attachments/assets/1f9f8809-2afe-4956-ac0a-de2579325143" />
