### PR TITLE
feat: attribute patch warnings to their originating patch

### DIFF
--- a/src/ISTAlter/Core/Patch.cs
+++ b/src/ISTAlter/Core/Patch.cs
@@ -174,7 +174,12 @@ public static partial class Patch
                 }
 
                 patch.AddAttemptedCount();
-                var patchedCount = patch.Delegator(module);
+                int patchedCount;
+                using (PatchUtils.BeginPatchScope(patch.Method.Name))
+                {
+                    patchedCount = patch.Delegator(module);
+                }
+
                 patch.AddAppliedCount(patchedCount);
                 if (patchedCount > 0)
                 {

--- a/src/ISTAlter/Core/PatchUtils.Base.cs
+++ b/src/ISTAlter/Core/PatchUtils.Base.cs
@@ -172,7 +172,7 @@ public static partial class PatchUtils
                 default:
                     if (instr.Operand != null)
                     {
-                        Log.Warning("Unhandled operand type {Type} in {Method}", instr.Operand.GetType(), method.FullName);
+                        LogPatchWarning("Unhandled operand type {Type} in {Method}", instr.Operand.GetType(), method.FullName);
                     }
 
                     break;
@@ -240,14 +240,14 @@ public static partial class PatchUtils
         var asyncStateMachineAttribute = method.CustomAttributes.FirstOrDefault(i => string.Equals(i.TypeFullName, "System.Runtime.CompilerServices.AsyncStateMachineAttribute", StringComparison.Ordinal));
         if (asyncStateMachineAttribute is not { ConstructorArguments: [{ Value: ValueTypeSig stateMachineType }] })
         {
-            Log.Warning("Required attribute not found, can not patch {Method}", method.FullName);
+            LogPatchWarning("Required attribute not found, can not patch {Method}", method.FullName);
             return 0;
         }
 
         var typeDef = stateMachineType.TypeDefOrRef.ResolveTypeDef();
         if (typeDef?.Methods.FirstOrDefault(m => m.Name == "MoveNext" && m.HasOverrides) is not { } generateMethod)
         {
-            Log.Warning("Required attribute not found, can not patch {Method}", method.FullName);
+            LogPatchWarning("Required attribute not found, can not patch {Method}", method.FullName);
             return 0;
         }
 

--- a/src/ISTAlter/Core/PatchUtils.Logging.cs
+++ b/src/ISTAlter/Core/PatchUtils.Logging.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright 2022-2026 TautCony
+
+namespace ISTAlter.Core;
+
+using Serilog;
+
+public static partial class PatchUtils
+{
+    private static readonly AsyncLocal<string?> CurrentPatchName = new();
+
+    /// <summary>
+    /// Marks the currently executing patch so that any warning logged through
+    /// <see cref="LogPatchWarning"/> while the scope is active is attributed to it.
+    /// Set once by the dispatcher around each patch invocation.
+    /// </summary>
+    /// <param name="patchName">The name of the patch being executed.</param>
+    /// <returns>A disposable that clears the attribution when the patch returns.</returns>
+    public static IDisposable BeginPatchScope(string patchName)
+    {
+        CurrentPatchName.Value = patchName;
+        return new PatchScope();
+    }
+
+    /// <summary>
+    /// Logs a warning that is tied to a specific patch, prefixing it with the patch
+    /// name captured by the active <see cref="BeginPatchScope"/>. Falls back to a plain
+    /// warning when no patch scope is active.
+    /// </summary>
+    /// <param name="messageTemplate">The Serilog message template.</param>
+    /// <param name="propertyValues">The values bound to the template placeholders.</param>
+    public static void LogPatchWarning(string messageTemplate, params object?[] propertyValues)
+    {
+        var patchName = CurrentPatchName.Value;
+        if (patchName == null)
+        {
+            Log.Warning(messageTemplate, propertyValues);
+            return;
+        }
+
+        var values = new object?[propertyValues.Length + 1];
+        values[0] = patchName;
+        Array.Copy(propertyValues, 0, values, 1, propertyValues.Length);
+        Log.Warning("[{PatchName}] " + messageTemplate, values);
+    }
+
+    private sealed class PatchScope : IDisposable
+    {
+        public void Dispose() => CurrentPatchName.Value = null;
+    }
+}

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -43,7 +43,7 @@ public static partial class PatchUtils
                     inst.OpCode == OpCodes.Call && inst.Operand is IMethod methodOperand &&
                     methodOperand.Name == "IsProgrammingEnabled") is not { } instruction)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -81,7 +81,7 @@ public static partial class PatchUtils
 
             if (apiInitExtCalls.Count < 2)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -91,7 +91,7 @@ public static partial class PatchUtils
 
             if (indexOfSecondCall is -1 or < 1)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -101,7 +101,7 @@ public static partial class PatchUtils
             var lastParamInstruction = method.Body.Instructions[indexOfSecondCall - 1];
             if (lastParamInstruction.OpCode != OpCodes.Ldstr)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -111,7 +111,7 @@ public static partial class PatchUtils
             var get_IPAddress = method.FindOperand<MemberRef>(OpCodes.Callvirt, "System.String \u0042\u004d\u0057.Rheingold.CoreFramework.Contracts.Vehicle.IVciDevice::get_IPAddress()");
             if (get_IPAddress == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -161,7 +161,7 @@ public static partial class PatchUtils
 
             if (dictionaryCtorRef == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -232,7 +232,7 @@ public static partial class PatchUtils
 
             if (get_CurrentOperation == null || setIsSendOBFCMDataIsForbidden == null || onPropertyChanged == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -269,7 +269,7 @@ public static partial class PatchUtils
 
             if (get_CurrentOperation == null || get_DataContext == null || get_VecInfo == null || set_IsSendFastaDataForbidden == null || setIsSendFastaDataIsForbidden == null || onPropertyChanged == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -337,14 +337,14 @@ public static partial class PatchUtils
             var sendFastaDataToFBMCall = method.FindInstruction(OpCodes.Callvirt, "System.String \u0042\u004d\u0057.Rheingold.RheingoldSessionController.Logic::SendFastaDataToFBM(System.String,System.Boolean)");
             if (sendFastaDataToFBMCall == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
             var indexOfCall = method.Body.Instructions.IndexOf(sendFastaDataToFBMCall);
             if (indexOfCall is -1 or < 1)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -352,7 +352,7 @@ public static partial class PatchUtils
             var booleanInstruction = method.Body.Instructions[indexOfCall - 1];
             if (!booleanInstruction.IsLdcI4())
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -471,7 +471,7 @@ public static partial class PatchUtils
                 }
             }
 
-            Log.Warning("Could not find EnumFASTATransferMode initialization pattern in {Method}", method.FullName);
+            LogPatchWarning("Could not find EnumFASTATransferMode initialization pattern in {Method}", method.FullName);
         }
     }
 
@@ -520,7 +520,7 @@ public static partial class PatchUtils
             var ctor = method.FindOperand<MemberRef>(OpCodes.Newobj, "System.Void System.Nullable`1<System.Boolean>::.ctor(System.Boolean)");
             if (ctor == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -568,7 +568,7 @@ public static partial class PatchUtils
 
         if (result == 0)
         {
-            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchUserEnvironmentProvider), module.Assembly.Name, version);
+            LogPatchWarning("found no applicable target in {Assembly}({Version})", module.Assembly.Name, version);
         }
 
         return result;
@@ -655,14 +655,14 @@ public static partial class PatchUtils
 
             if (indexOfRequestSwtAction == -1)
             {
-                Log.Warning("Required instructions not found (neither old nor new signature), can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found (neither old nor new signature), can not patch {Method}", method.FullName);
                 return;
             }
 
             var ldcI4One = method.Body.Instructions[indexOfRequestSwtAction - 1];
             if (!ldcI4One.IsLdcI4())
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -698,14 +698,14 @@ public static partial class PatchUtils
 
             if (indexOfRequestSwtAction == -1)
             {
-                Log.Warning("Required instructions not found (neither old nor new signature), can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found (neither old nor new signature), can not patch {Method}", method.FullName);
                 return;
             }
 
             var ldcI4One = instructions[indexOfRequestSwtAction - 1];
             if (!ldcI4One.IsLdcI4())
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -751,7 +751,7 @@ public static partial class PatchUtils
             var indexOfCallIsILeanActive = method.FindIndexOfInstruction(OpCodes.Call, "System.Boolean \u0042\u004d\u0057.Rheingold.CoreFramework.ConfigSettings::get_IsILeanActive()");
             if (indexOfCallIsILeanActive == -1)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -797,7 +797,7 @@ public static partial class PatchUtils
 
         if (result == 0)
         {
-            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchFixDS2VehicleIdent), module.Assembly.Name, version);
+            LogPatchWarning("found no applicable target in {Assembly}({Version})", module.Assembly.Name, version);
         }
 
         return result;
@@ -825,7 +825,7 @@ public static partial class PatchUtils
 
             if (!handleMissingEcusProcessed)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -834,7 +834,7 @@ public static partial class PatchUtils
             var getBNType = method.FindOperand<MemberRef>(OpCodes.Callvirt, "\u0042\u004d\u0057.Rheingold.CoreFramework.DatabaseProvider.BNType \u0042\u004d\u0057.Rheingold.CoreFramework.DatabaseProvider.typeVehicle::get_BNType()");
             if (indexOfSetIdentSuccessfully == -1 || getVecInfo == null || getBNType == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -894,7 +894,7 @@ public static partial class PatchUtils
 
             if (indexSetIdent == -1)
             {
-                Log.Warning("Could not find set_IDENT_SUCCESSFULLY in foreach loop in {Method}", method.FullName);
+                LogPatchWarning("Could not find set_IDENT_SUCCESSFULLY in foreach loop in {Method}", method.FullName);
                 return;
             }
 
@@ -907,7 +907,7 @@ public static partial class PatchUtils
 
             if (getVecInfo == null || getBNType == null)
             {
-                Log.Warning("Required method references not found in {Method}", method.FullName);
+                LogPatchWarning("Required method references not found in {Method}", method.FullName);
                 return;
             }
 
@@ -985,7 +985,7 @@ public static partial class PatchUtils
 
         if (result == 0)
         {
-            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchMotorbikeClamp15), module.Assembly.Name, version);
+            LogPatchWarning("found no applicable target in {Assembly}({Version})", module.Assembly.Name, version);
         }
 
         return result;
@@ -1001,21 +1001,21 @@ public static partial class PatchUtils
             var hasValueCall = method.FindInstruction(OpCodes.Call, "System.Boolean System.Nullable`1<System.Double>::get_HasValue()");
             if (hasValueCall == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
             var hasValueIndex = instructions.IndexOf(hasValueCall);
             if (hasValueIndex == -1 || hasValueIndex >= instructions.Count - 1)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
             var brfalseInstruction = instructions[hasValueIndex + 1];
             if (brfalseInstruction.OpCode != OpCodes.Brfalse_S)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -1024,7 +1024,7 @@ public static partial class PatchUtils
 
             if (valueComparisonBrfalse == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -1071,7 +1071,7 @@ public static partial class PatchUtils
 
             if (tryStartIdx == -1 || vehicleAccess == null || getVci == null || getVciType == null)
             {
-                Log.Warning("Could not find VCIType check pattern in {Method}", method.FullName);
+                LogPatchWarning("Could not find VCIType check pattern in {Method}", method.FullName);
                 return;
             }
 
@@ -1154,7 +1154,7 @@ public static partial class PatchUtils
                 localize == null || progressWaitCtor == null || register == null ||
                 checkForAutoSkip == null || getInteractionService == null)
             {
-                Log.Warning("Could not find existing method references in {Method}", method.FullName);
+                LogPatchWarning("Could not find existing method references in {Method}", method.FullName);
                 return;
             }
 
@@ -1187,7 +1187,7 @@ public static partial class PatchUtils
 
             if (func7000 == null || func9000 == null)
             {
-                Log.Warning("Lambda functions for voltage checks not found in {Method}", method.FullName);
+                LogPatchWarning("Lambda functions for voltage checks not found in {Method}", method.FullName);
                 return;
             }
 
@@ -1286,7 +1286,7 @@ public static partial class PatchUtils
 
             if (singletonField == null || lambda7000Method == null || lambda9000Method == null || funcConstructor == null)
             {
-                Log.Warning("Could not find all required components for lazy initialization in {Method}", method.FullName);
+                LogPatchWarning("Could not find all required components for lazy initialization in {Method}", method.FullName);
                 return;
             }
 
@@ -1298,7 +1298,7 @@ public static partial class PatchUtils
             var leaveInstruction = instructions.FirstOrDefault(i => i.OpCode == OpCodes.Leave || i.OpCode == OpCodes.Leave_S);
             if (leaveInstruction == null)
             {
-                Log.Warning("Could not find leave instruction in {Method}", method.FullName);
+                LogPatchWarning("Could not find leave instruction in {Method}", method.FullName);
                 return;
             }
 

--- a/src/ISTAlter/Core/PatchUtils.cs
+++ b/src/ISTAlter/Core/PatchUtils.cs
@@ -182,7 +182,7 @@ public static partial class PatchUtils
             if (getBaseService == null || getPSdZProperties == null || setPSdZProperties == null || putProperty == null ||
                 stringImplicit == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -191,7 +191,7 @@ public static partial class PatchUtils
                 var property = method.GetLocalByType("java.util.Properties");
                 if (property == null || method.Body.Variables.Count == 0)
                 {
-                    Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                    LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                     return;
                 }
 
@@ -301,7 +301,7 @@ public static partial class PatchUtils
 
             if (patchCount == 0)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
             }
         }
     }
@@ -368,7 +368,7 @@ public static partial class PatchUtils
             var invalidOperationException = method.FindOperand<MemberRef>(OpCodes.Newobj, "System.Void System.InvalidOperationException::.ctor(System.String)");
             if (getProcessesByName == null || firstOrDefault == null || invalidOperationException == null)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
@@ -499,7 +499,7 @@ public static partial class PatchUtils
                 }
                 else
                 {
-                    Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                    LogPatchWarning("Required instructions not found, can not patch {Method}", method.FullName);
                 }
             }
         };


### PR DESCRIPTION
## Attribute patch warnings to their originating patch

### Problem
Warnings raised from inside a patch (e.g. `Required method references not found in <method>`) only reported the target IL method, not *which patch* failed. The patch-level warnings (`{PatchName} found no applicable target …`) already carry the patch name, so the diagnostics were inconsistent — when a patch silently fails mid-transformation on a new ISTA version, you can't tell which one from the log line alone.

### Change
The patch name is captured **once**, at the dispatch site in `Patch.cs`, into an ambient `AsyncLocal` scope (`PatchUtils.BeginPatchScope`). Patch warnings now go through a small helper, `LogPatchWarning`, which prefixes `[{PatchName}]` read from that scope and falls back to a plain `Log.Warning` when no patch is active. No per-call-site duplication of the patch name.

Result:

```
[WRN] [PatchExample1] Required method references not found in …::Blabla(…)
[WRN] [PatchExample2] found no applicable target in SomeDLL(4.59.30.33249)
```

### Design notes / open question
I deliberately avoided threading `nameof(PatchX)` through every call site (duplication) and `[CallerMemberName]` (doesn't propagate into the nested local functions where most of these warnings live).

Since `FromLogContext()` is already enabled, an alternative would be `LogContext.PushProperty("PatchName", …)` at the dispatcher. I didn't use it as the primary mechanism because a `{PatchName}` token in a *message* template isn't filled from `LogContext` (positional binding) — it would only render via a change to the global console `outputTemplate`, which would affect every other log line. The ambient-scope + helper keeps the prefix scoped to patch warnings only, with no template change and no new dependency.

Happy to switch to a `LogContext`-based variant if you'd prefer to lean on the existing enricher.
