### PR TITLE
feat: block EDGE telemetry egress (Speedlink + OBFCM) in DataNotSend

### DIFF
--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -420,15 +420,6 @@ public static partial class PatchUtils
     [FromVersion("4.55")]
     public static int PatchEdgeTelemetry(ModuleDefMD module)
     {
-        // EDGE telemetry egress that the IsSend*Forbidden flags do NOT gate. These two senders fire
-        // the HTTP POST unconditionally (the forbidden flag only rides inside the payload), so the
-        // request still leaves the machine. Empty their bodies -> the telemetry call never happens.
-        //
-        // SCOPE: telemetry only — Speedlink (session/dealer) + OBFCM (fuel data to the Vehicle Shadow
-        // backend). EDGEBattery / EDGEPDI are intentionally left FUNCTIONAL (their response drives
-        // features). To extend to "zero EDGE egress", empty
-        // BMW.Rheingold.InfoProvider.EDGE.EDGEProcessorImpl::SendDataToBackend instead (single
-        // chokepoint, but blocks ALL channels including battery/PDI).
         return module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.RheingoldSessionController.Logic",
             "SendSpeedlinkDataInBackground",
@@ -439,6 +430,19 @@ public static partial class PatchUtils
             "SendObfcmDataToVehicleShadowBackend",
             "(\u0042\u004d\u0057.Rheingold.InfoProvider.EDGE.Models.OBFCM.OBFCMData,System.String)System.Void",
             DnlibUtils.EmptyingMethod
+        );
+    }
+
+    [NotSendPatch]
+    [LibraryName("RheingoldInfoProvider.dll")]
+    [FromVersion("4.55")]
+    public static int PatchSccVehicleSession(ModuleDefMD module)
+    {
+        return module.PatchFunction(
+            "\u0042\u004d\u0057.Rheingold.InfoProvider.SCC.SCCProcessorImpl",
+            "PostVehicleSession",
+            "(System.Collections.Generic.IEnumerable`1<System.String>,\u0042\u004d\u0057.Rheingold.InfoProvider.SCC.Models.VehicleSession)System.Net.HttpStatusCode",
+            DnlibUtils.ReturnUInt32Method((uint)System.Net.HttpStatusCode.ServiceUnavailable)
         );
     }
 

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: Copyright 2022-2026 TautCony
 
 namespace ISTAlter.Core;
@@ -412,6 +412,33 @@ public static partial class PatchUtils
             "\u0042\u004d\u0057.Rheingold.RheingoldSessionController.Logic",
             "IsSendOBFCMDataForbidden",
             DnlibUtils.ReturnTrueMethod
+        );
+    }
+
+    [NotSendPatch]
+    [LibraryName("RheingoldSessionController.dll")]
+    [FromVersion("4.55")]
+    public static int PatchEdgeTelemetry(ModuleDefMD module)
+    {
+        // EDGE telemetry egress that the IsSend*Forbidden flags do NOT gate. These two senders fire
+        // the HTTP POST unconditionally (the forbidden flag only rides inside the payload), so the
+        // request still leaves the machine. Empty their bodies -> the telemetry call never happens.
+        //
+        // SCOPE: telemetry only — Speedlink (session/dealer) + OBFCM (fuel data to the Vehicle Shadow
+        // backend). EDGEBattery / EDGEPDI are intentionally left FUNCTIONAL (their response drives
+        // features). To extend to "zero EDGE egress", empty
+        // BMW.Rheingold.InfoProvider.EDGE.EDGEProcessorImpl::SendDataToBackend instead (single
+        // chokepoint, but blocks ALL channels including battery/PDI).
+        return module.PatchFunction(
+            "\u0042\u004d\u0057.Rheingold.RheingoldSessionController.Logic",
+            "SendSpeedlinkDataInBackground",
+            "()System.Void",
+            DnlibUtils.EmptyingMethod
+        ) + module.PatchFunction(
+            "\u0042\u004d\u0057.Rheingold.RheingoldSessionController.Logic",
+            "SendObfcmDataToVehicleShadowBackend",
+            "(\u0042\u004d\u0057.Rheingold.InfoProvider.EDGE.Models.OBFCM.OBFCMData,System.String)System.Void",
+            DnlibUtils.EmptyingMethod
         );
     }
 


### PR DESCRIPTION
The IsSend*Forbidden flags do not gate these channels: Logic.SendSpeedlinkDataInBackground and SendObfcmDataToVehicleShadowBackend fire the HTTP POST unconditionally (the forbidden flag only rides inside the payload), so the request still leaves the machine. Empty both senders (DnlibUtils.EmptyingMethod) so the telemetry call never happens.

Scope: telemetry only -- Speedlink (session/dealer) + OBFCM (fuel data to Vehicle Shadow). EDGEBattery / EDGEPDI are left functional. To extend to zero EDGE egress, empty EDGEProcessorImpl.SendDataToBackend instead (single chokepoint, blocks all channels).

Also blocks the SCC "vehicle session" upload (SCCProcessorImpl.PostVehicleSession, invoked
from IstaOperationLogic.SaveCurrentSCCCase on session close), which is likewise not gated
by the IsSend*Forbidden flags -- it fires unconditionally and posts VIN + vehicle data +
DiagnosisData (DTCs, diagnosis codes, technician statements) + PDF diagnosis files to the
SCC backend. Returns the method's own "offline" sentinel (HttpStatusCode.ServiceUnavailable),
which the caller already treats as "not Created" and discards, so the HTTP call -- and the
subsequent PDF upload (PostFiles), only reached on Created -- never happens.
