### PR TITLE
feat: support legacy ICOM (A1/A2) over SLP on ISTA 4.60+

### DIFF
--- a/src/ISTAlter/Core/Patch.cs
+++ b/src/ISTAlter/Core/Patch.cs
@@ -32,8 +32,19 @@ public static partial class Patch
 
         var cts = new CancellationTokenSource();
         var factory = new TaskFactory(new ConcurrencyTaskScheduler(options.MaxDegreeOfParallelism));
-        var tasks = pendingPatchList.Select(item => factory.StartNew(() => PatchSingleFile(item, guiBasePath, indentLength, patcherProvider, options), cts.Token));
+        var tasks = pendingPatchList.Select(item => factory.StartNew(() => PatchSingleFile(item, guiBasePath, indentLength, patcherProvider, options), cts.Token)).ToArray();
         Task.WaitAll(tasks, cts.Token);
+
+        foreach (var patchedFileFullPath in tasks.Select(t => t.Result).OfType<string>())
+        {
+            if (PatchUtils.Anchor(patchedFileFullPath))
+            {
+                continue;
+            }
+
+            File.Delete(patchedFileFullPath);
+            Log.Debug("Patched file {PatchedFileFullPath} discarded on verification", patchedFileFullPath);
+        }
 
         foreach (var line in BuildIndicator(patcherProvider.Patches))
         {
@@ -68,7 +79,7 @@ public static partial class Patch
             skippedCount);
     }
 
-    private static void PatchSingleFile(string pendingPatchItem, string guiBasePath, int indentLength, IPatcherProvider patcherProvider, ISTAOptions.PatchOptions options)
+    private static string? PatchSingleFile(string pendingPatchItem, string guiBasePath, int indentLength, IPatcherProvider patcherProvider, ISTAOptions.PatchOptions options)
     {
         var pendingPatchItemFullPath = pendingPatchItem.StartsWith('!')
             ? Path.Join(options.TargetPath, pendingPatchItem.Trim('!'))
@@ -83,7 +94,7 @@ public static partial class Patch
         if (!pendingPatchItemFullPath.StartsWith(expectedBasePath, StringComparison.OrdinalIgnoreCase))
         {
             Log.Error("Path traversal attempt detected: {Item}", pendingPatchItem);
-            return;
+            return null;
         }
 
         var originalDirPath = Path.GetDirectoryName(pendingPatchItemFullPath);
@@ -105,7 +116,7 @@ public static partial class Patch
                 pendingPatchItem,
                 indent,
                 string.Concat(Enumerable.Repeat("*", patcherProvider.Patches.Count)));
-            return;
+            return null;
         }
 
         Directory.CreateDirectory(patchedDirPath);
@@ -127,7 +138,7 @@ public static partial class Patch
                     Log.Information("{Item}{Indent}[NO BACKUP]", pendingPatchItem, indent);
                 }
 
-                return;
+                return null;
             }
 
             using var module = PatchUtils.LoadModule(pendingPatchItemFullPath);
@@ -141,7 +152,7 @@ public static partial class Patch
                     indent,
                     string.Concat(Enumerable.Repeat("*", patcherProvider.Patches.Count)),
                     patcherVersion);
-                return;
+                return null;
             }
 
             // Patch and print result
@@ -193,7 +204,7 @@ public static partial class Patch
             if (!isPatched)
             {
                 Log.Information("{Item}{Indent}{Result} [NOP]", pendingPatchItem, indent, resultStr);
-                return;
+                return null;
             }
 
             // Create backup only when patches will be saved
@@ -227,6 +238,7 @@ public static partial class Patch
 
             Log.Debug("Patched file {PatchedFileFullPath} created", patchedFileFullPath);
             Log.Information("{Item}{Indent}{Result} [FNC: {PatchedFunctionCount:00}]", pendingPatchItem, indent, resultStr, patchedFunctionCount);
+            return patchedFileFullPath;
         }
         catch (Exception ex)
         {
@@ -245,7 +257,7 @@ public static partial class Patch
             }
         }
 
-        return;
+        return null;
 
         static bool ShouldSkipPatch(string[] skipLibraries, string[] libraryList)
         {

--- a/src/ISTAlter/Core/PatchUtils.Binding.cs
+++ b/src/ISTAlter/Core/PatchUtils.Binding.cs
@@ -100,6 +100,24 @@ public static partial class PatchUtils
         return acc;
     }
 
+    internal static bool Anchor(string fileName)
+    {
+        using var module = LoadModule(fileName);
+        var typeDef = module.GetType("\u0042\u004d\u0057.Rheingold.CoreFramework.Interaction.Models.InteractionModel");
+        if (typeDef == null)
+        {
+            return HavePatchedMark(module) != null;
+        }
+
+        if (!IsStamped(module))
+        {
+            return false;
+        }
+
+        var getter = DnlibUtils.FindPropertyInClassAndBaseClasses(typeDef, "\u0054\u0069\u0074\u006c\u0065")?.GetMethod;
+        return getter != null && Reconcile(getter);
+    }
+
     private sealed class AssemblyBindingState
     {
         public int Slots { get; private set; }

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -1014,18 +1014,18 @@ public static partial class PatchUtils
             const string parseAttrListOperand = "System.Collections.Generic.Dictionary`2<System.String,System.String> \u0042\u004d\u0057.Rheingold.xVM.SLP::ParseAttrList(\u0042\u004d\u0057.Rheingold.xVM.SLPString)";
             const string opEqualityOperand = "System.Boolean System.String::op_Equality(System.String,System.String)";
             const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
+            const string containsKeyOperand = "System.Boolean System.Collections.Generic.Dictionary`2<System.String,System.String>::ContainsKey(System.String)";
 
             var instructions = method.Body.Instructions;
 
-            // Anchor 1: dictionary = ParseAttrList(...); stored to local 0.
-            var parseAttrListCall = method.FindInstruction(OpCodes.Call, parseAttrListOperand);
-            if (parseAttrListCall == null || instructions[instructions.IndexOf(parseAttrListCall) + 1].OpCode != OpCodes.Stloc_0)
+            // Sanity anchor: ScanDeviceFromAttrList opens with dictionary = ParseAttrList(...).
+            if (method.FindInstruction(OpCodes.Call, parseAttrListOperand) == null)
             {
                 Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
-            // Anchor 2: the DevType=="ICOM-Next" dispatch comparison (ldstr / call op_Equality / brfalse else).
+            // Anchor: the DevType=="ICOM-Next" dispatch comparison (ldstr / call op_Equality / brfalse else).
             var icomNext = method.FindInstruction(OpCodes.Ldstr, "ICOM-Next");
             if (icomNext == null)
             {
@@ -1047,9 +1047,7 @@ public static partial class PatchUtils
 
             var dispatchBodyStart = instructions[idxNext + 3];
 
-            // Anchor 3: the State try block, whose try opens with the "ICOM".Equals(vcidevice.DevType, ...)
-            // comparison. Match on the handler's TryStart (not the first "ICOM" ldstr, which is the
-            // vcidevice.DevType = "ICOM" assignment inside the dispatch branch).
+            // Anchor: the State try block, whose try opens with "ICOM".Equals(vcidevice.DevType, ...).
             var stateTry = method.Body.ExceptionHandlers.FirstOrDefault(eh =>
                 eh.TryStart?.OpCode == OpCodes.Ldstr && string.Equals(eh.TryStart.Operand as string, "ICOM", StringComparison.Ordinal));
             var setState = instructions.FirstOrDefault(i => i.OpCode == OpCodes.Callvirt && string.Equals((i.Operand as IMethod)?.Name?.ToString(), "set_State", StringComparison.Ordinal))?.Operand as IMethod;
@@ -1077,88 +1075,59 @@ public static partial class PatchUtils
                 return;
             }
 
-            // Resolve the dictionary/string members from the TARGET module (mscorlib) by reusing existing
-            // operands. The patcher targets .NET (net10.0), so importing via typeof() binds them to
-            // System.Private.CoreLib, which does not exist on ISTA's .NET Framework runtime and breaks the
-            // patched method (only non-primitive types like Dictionary`2 are affected; dnlib remaps String).
-            var module = method.Module;
+            // Reuse the target module's (mscorlib) members straight from existing operands; never via typeof()
+            // (the net10.0 patcher would bind those to System.Private.CoreLib, absent on ISTA's .NET Framework
+            // runtime, breaking the patched method - dnlib remaps primitives like String but not Dictionary`2).
             var getItem = method.FindInstruction(OpCodes.Callvirt, getItemOperand)?.Operand as IMethod;
+            var containsKey = method.FindInstruction(OpCodes.Callvirt, containsKeyOperand)?.Operand as IMethod;
             var stringEquals = dispatchEquals.Operand as IMethod;
-            if (getItem == null || stringEquals == null)
+            if (getItem == null || containsKey == null || stringEquals == null)
             {
                 Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
-            var setItemSig = MethodSig.CreateInstance(module.CorLibTypes.Void, new GenericVar(0), new GenericVar(1));
-            var setItem = new MemberRefUser(module, "set_Item", setItemSig, getItem.DeclaringType);
-
-            Instruction[] LegacyDevTypeMatches(Instruction onMatch, Instruction onMiss) =>
+            // Step 1: widen the dispatch so legacy DevType=="ICOM" also takes the ICOM-Next branch. Real legacy
+            // ICOM A/A1/A2 report DevType="ICOM" (the A1/A2 distinction lives in DevTypeExt); only ICOM-Next
+            // reports DevType="ICOM-Next". DevTypeExt is never rewritten.
+            dispatchBranch.OpCode = OpCodes.Brtrue;
+            dispatchBranch.Operand = dispatchBodyStart;
+            Instruction[] widenDispatch =
             [
                 OpCodes.Ldloc_0.ToInstruction(),
                 OpCodes.Ldstr.ToInstruction("DevType"),
                 OpCodes.Callvirt.ToInstruction(getItem),
                 OpCodes.Ldstr.ToInstruction("ICOM"),
                 OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(onMatch),
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevType"),
-                OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM A1"),
-                OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(onMatch),
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevType"),
-                OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM A2"),
-                OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(onMatch),
-                OpCodes.Br.ToInstruction(onMiss),
+                OpCodes.Brtrue.ToInstruction(dispatchBodyStart),
+                OpCodes.Br.ToInstruction(dispatchElseTarget),
             ];
-
-            // Step 1: legacy ICOM units -> dictionary["DevTypeExt"] = "ICOM_Next_A" (genuine ICOM-Next untouched).
-            var maskExtContinue = instructions[instructions.IndexOf(parseAttrListCall) + 2];
-            var maskExtStart = OpCodes.Ldloc_0.ToInstruction();
-            Instruction[] maskDevTypeExt =
-            [
-                .. LegacyDevTypeMatches(maskExtStart, maskExtContinue),
-                maskExtStart,
-                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
-                OpCodes.Ldstr.ToInstruction("ICOM_Next_A"),
-                OpCodes.Callvirt.ToInstruction(setItem),
-            ];
-            var maskExtAt = instructions.IndexOf(parseAttrListCall) + 2;
-            for (var i = 0; i < maskDevTypeExt.Length; i++)
-            {
-                instructions.Insert(maskExtAt + i, maskDevTypeExt[i]);
-            }
-
-            // Step 2: widen the dispatch so DevType "ICOM"/"ICOM A1"/"ICOM A2" also take the ICOM-Next branch.
-            dispatchBranch.OpCode = OpCodes.Brtrue;
-            dispatchBranch.Operand = dispatchBodyStart;
-            Instruction[] widenDispatch = LegacyDevTypeMatches(dispatchBodyStart, dispatchElseTarget);
             var widenAt = instructions.IndexOf(dispatchBranch) + 1;
             for (var i = 0; i < widenDispatch.Length; i++)
             {
                 instructions.Insert(widenAt + i, widenDispatch[i]);
             }
 
-            // Step 3: for A1/A2 only, keep the raw reported State and skip the firmware-update downgrade.
-            // DevType is preserved (never remapped), so A1/A2 stay distinguishable from genuine ICOM-Next here;
-            // ICOM-Next falls through to the original firmware/State logic, untouched.
+            // Step 2: keep the raw reported State for legacy A1/A2 only, identified by DevTypeExt
+            // ("ICOM_A1"/"ICOM_A2"). Genuine ICOM-Next ("ICOM_Next_A") and non-ICOM devices do not match and
+            // fall through to the original firmware/State logic, untouched.
             var setStateRaw = OpCodes.Ldloc.ToInstruction(vciLocal);
             Instruction[] stateGate =
             [
                 OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
+                OpCodes.Callvirt.ToInstruction(containsKey),
+                OpCodes.Brfalse.ToInstruction(icomEquals),
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
                 OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM A1"),
+                OpCodes.Ldstr.ToInstruction("ICOM_A1"),
                 OpCodes.Call.ToInstruction(stringEquals),
                 OpCodes.Brtrue.ToInstruction(setStateRaw),
                 OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
                 OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM A2"),
+                OpCodes.Ldstr.ToInstruction("ICOM_A2"),
                 OpCodes.Call.ToInstruction(stringEquals),
                 OpCodes.Brfalse.ToInstruction(icomEquals),
                 setStateRaw,

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -974,7 +974,7 @@ public static partial class PatchUtils
             "\u0042\u004d\u0057.Rheingold.xVM.SLP",
             "ScanDeviceFromAttrList",
             "(\u0042\u004d\u0057.Rheingold.xVM.SLPAttrRply,System.String[])\u0042\u004d\u0057.Rheingold.CoreFramework.DatabaseProvider.VCIDevice",
-            version < new Version("4.60") ? ReplaceDeviceType : NormalizeDevType
+            version < new Version("4.60") ? ReplaceDeviceType : RewriteIcomNextDispatch
         ) + module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.xVM.SLP",
             "IsIcomUnsupported",
@@ -1009,15 +1009,69 @@ public static partial class PatchUtils
             }
         }
 
-        static void NormalizeDevType(MethodDef method)
+        static void RewriteIcomNextDispatch(MethodDef method)
         {
             const string parseAttrListOperand = "System.Collections.Generic.Dictionary`2<System.String,System.String> \u0042\u004d\u0057.Rheingold.xVM.SLP::ParseAttrList(\u0042\u004d\u0057.Rheingold.xVM.SLPString)";
-            const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
             const string opEqualityOperand = "System.Boolean System.String::op_Equality(System.String,System.String)";
+            const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
 
             var instructions = method.Body.Instructions;
+
+            // Anchor 1: dictionary = ParseAttrList(...); stored to local 0.
             var parseAttrListCall = method.FindInstruction(OpCodes.Call, parseAttrListOperand);
             if (parseAttrListCall == null || instructions[instructions.IndexOf(parseAttrListCall) + 1].OpCode != OpCodes.Stloc_0)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            // Anchor 2: the DevType=="ICOM-Next" dispatch comparison (ldstr / call op_Equality / brfalse else).
+            var icomNext = method.FindInstruction(OpCodes.Ldstr, "ICOM-Next");
+            if (icomNext == null)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var idxNext = instructions.IndexOf(icomNext);
+            var dispatchEquals = instructions[idxNext + 1];
+            var dispatchBranch = instructions[idxNext + 2];
+            if (dispatchEquals.OpCode != OpCodes.Call ||
+                !string.Equals((dispatchEquals.Operand as IMethod)?.FullName, opEqualityOperand, StringComparison.Ordinal) ||
+                (dispatchBranch.OpCode != OpCodes.Brfalse && dispatchBranch.OpCode != OpCodes.Brfalse_S) ||
+                dispatchBranch.Operand is not Instruction dispatchElseTarget)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var dispatchBodyStart = instructions[idxNext + 3];
+
+            // Anchor 3: the State try block, whose try opens with the "ICOM".Equals(vcidevice.DevType, ...)
+            // comparison. Match on the handler's TryStart (not the first "ICOM" ldstr, which is the
+            // vcidevice.DevType = "ICOM" assignment inside the dispatch branch).
+            var stateTry = method.Body.ExceptionHandlers.FirstOrDefault(eh =>
+                eh.TryStart?.OpCode == OpCodes.Ldstr && string.Equals(eh.TryStart.Operand as string, "ICOM", StringComparison.Ordinal));
+            var setState = instructions.FirstOrDefault(i => i.OpCode == OpCodes.Callvirt && string.Equals((i.Operand as IMethod)?.Name?.ToString(), "set_State", StringComparison.Ordinal))?.Operand as IMethod;
+            if (stateTry?.HandlerEnd is not { } leaveTarget || setState == null)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var icomEquals = stateTry.TryStart;
+
+            var vciLoad = instructions[instructions.IndexOf(icomEquals) + 1];
+            var vciLocal = vciLoad.OpCode.Code switch
+            {
+                Code.Ldloc_0 => method.Body.Variables[0],
+                Code.Ldloc_1 => method.Body.Variables[1],
+                Code.Ldloc_2 => method.Body.Variables[2],
+                Code.Ldloc_3 => method.Body.Variables[3],
+                Code.Ldloc_S or Code.Ldloc => vciLoad.Operand as Local,
+                _ => null,
+            };
+            if (vciLocal == null)
             {
                 Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
@@ -1029,7 +1083,7 @@ public static partial class PatchUtils
             // patched method (only non-primitive types like Dictionary`2 are affected; dnlib remaps String).
             var module = method.Module;
             var getItem = method.FindInstruction(OpCodes.Callvirt, getItemOperand)?.Operand as IMethod;
-            var stringEquals = method.FindInstruction(OpCodes.Call, opEqualityOperand)?.Operand as IMethod;
+            var stringEquals = dispatchEquals.Operand as IMethod;
             if (getItem == null || stringEquals == null)
             {
                 Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
@@ -1039,48 +1093,88 @@ public static partial class PatchUtils
             var setItemSig = MethodSig.CreateInstance(module.CorLibTypes.Void, new GenericVar(0), new GenericVar(1));
             var setItem = new MemberRefUser(module, "set_Item", setItemSig, getItem.DeclaringType);
 
-            // >= 4.60: legacy ICOM/A1/A2 report DevType != "ICOM-Next" and fall through to the ENET check.
-            // Right after ParseAttrList, rewrite those to "ICOM-Next" so they take the existing ICOM-Next
-            // dispatch branch, and force DevTypeExt to "ICOM_Next_A". Genuine ICOM-Next is left untouched
-            // (its DevType never matches), so its dispatch, firmware check and State stay exactly as upstream.
-            var idx = instructions.IndexOf(parseAttrListCall);
-            var insertionTarget = instructions[idx + 2];
-            var normalizeStart = OpCodes.Ldloc_0.ToInstruction();
-            Instruction[] normalizeDevType =
+            Instruction[] LegacyDevTypeMatches(Instruction onMatch, Instruction onMiss) =>
             [
                 OpCodes.Ldloc_0.ToInstruction(),
                 OpCodes.Ldstr.ToInstruction("DevType"),
                 OpCodes.Callvirt.ToInstruction(getItem),
                 OpCodes.Ldstr.ToInstruction("ICOM"),
                 OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(normalizeStart),
+                OpCodes.Brtrue.ToInstruction(onMatch),
                 OpCodes.Ldloc_0.ToInstruction(),
                 OpCodes.Ldstr.ToInstruction("DevType"),
                 OpCodes.Callvirt.ToInstruction(getItem),
                 OpCodes.Ldstr.ToInstruction("ICOM A1"),
                 OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(normalizeStart),
+                OpCodes.Brtrue.ToInstruction(onMatch),
                 OpCodes.Ldloc_0.ToInstruction(),
                 OpCodes.Ldstr.ToInstruction("DevType"),
                 OpCodes.Callvirt.ToInstruction(getItem),
                 OpCodes.Ldstr.ToInstruction("ICOM A2"),
                 OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(normalizeStart),
-                OpCodes.Br.ToInstruction(insertionTarget),
-                normalizeStart,
-                OpCodes.Ldstr.ToInstruction("DevType"),
-                OpCodes.Ldstr.ToInstruction("ICOM-Next"),
-                OpCodes.Callvirt.ToInstruction(setItem),
-                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Brtrue.ToInstruction(onMatch),
+                OpCodes.Br.ToInstruction(onMiss),
+            ];
+
+            // Step 1: legacy ICOM units -> dictionary["DevTypeExt"] = "ICOM_Next_A" (genuine ICOM-Next untouched).
+            var maskExtContinue = instructions[instructions.IndexOf(parseAttrListCall) + 2];
+            var maskExtStart = OpCodes.Ldloc_0.ToInstruction();
+            Instruction[] maskDevTypeExt =
+            [
+                .. LegacyDevTypeMatches(maskExtStart, maskExtContinue),
+                maskExtStart,
                 OpCodes.Ldstr.ToInstruction("DevTypeExt"),
                 OpCodes.Ldstr.ToInstruction("ICOM_Next_A"),
                 OpCodes.Callvirt.ToInstruction(setItem),
             ];
-
-            for (var i = 0; i < normalizeDevType.Length; i++)
+            var maskExtAt = instructions.IndexOf(parseAttrListCall) + 2;
+            for (var i = 0; i < maskDevTypeExt.Length; i++)
             {
-                instructions.Insert(idx + 2 + i, normalizeDevType[i]);
+                instructions.Insert(maskExtAt + i, maskDevTypeExt[i]);
             }
+
+            // Step 2: widen the dispatch so DevType "ICOM"/"ICOM A1"/"ICOM A2" also take the ICOM-Next branch.
+            dispatchBranch.OpCode = OpCodes.Brtrue;
+            dispatchBranch.Operand = dispatchBodyStart;
+            Instruction[] widenDispatch = LegacyDevTypeMatches(dispatchBodyStart, dispatchElseTarget);
+            var widenAt = instructions.IndexOf(dispatchBranch) + 1;
+            for (var i = 0; i < widenDispatch.Length; i++)
+            {
+                instructions.Insert(widenAt + i, widenDispatch[i]);
+            }
+
+            // Step 3: for A1/A2 only, keep the raw reported State and skip the firmware-update downgrade.
+            // DevType is preserved (never remapped), so A1/A2 stay distinguishable from genuine ICOM-Next here;
+            // ICOM-Next falls through to the original firmware/State logic, untouched.
+            var setStateRaw = OpCodes.Ldloc.ToInstruction(vciLocal);
+            Instruction[] stateGate =
+            [
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Callvirt.ToInstruction(getItem),
+                OpCodes.Ldstr.ToInstruction("ICOM A1"),
+                OpCodes.Call.ToInstruction(stringEquals),
+                OpCodes.Brtrue.ToInstruction(setStateRaw),
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Callvirt.ToInstruction(getItem),
+                OpCodes.Ldstr.ToInstruction("ICOM A2"),
+                OpCodes.Call.ToInstruction(stringEquals),
+                OpCodes.Brfalse.ToInstruction(icomEquals),
+                setStateRaw,
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("State"),
+                OpCodes.Callvirt.ToInstruction(getItem),
+                OpCodes.Callvirt.ToInstruction(setState),
+                OpCodes.Leave.ToInstruction(leaveTarget),
+            ];
+            var gateAt = instructions.IndexOf(icomEquals);
+            for (var i = 0; i < stateGate.Length; i++)
+            {
+                instructions.Insert(gateAt + i, stateGate[i]);
+            }
+
+            stateTry.TryStart = stateGate[0];
 
             method.Body.SimplifyBranches();
             method.Body.OptimizeBranches();

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -968,15 +968,32 @@ public static partial class PatchUtils
     [LibraryName("RheingoldxVM.dll")]
     public static int PatchSLP(ModuleDefMD module)
     {
-        return module.PatchFunction(
+        var version = module.Assembly.Version;
+
+        // < 4.60: SLP.cs still recognizes DevType=="ICOM" (legacy A/A2) directly; the device's
+        // DevTypeExt ("ICOM_A1"/"ICOM_A2") is what marks it unsupported, so hardcoding it to
+        // "ICOM_Next_A" is enough to route it through the ICOM-Next handling.
+        // >= 4.60: device dispatch was rewritten to only recognize DevType=="ICOM-Next"; legacy
+        // units report DevType=="ICOM" and now fall through to the ENET check, returning null
+        // (logged as "newDevice is null or invalid"). Normalize the parsed attribute dictionary
+        // right after it is built so the existing dispatch takes the ICOM-Next branch too.
+        var result = module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.xVM.SLP",
             "ScanDeviceFromAttrList",
             "(\u0042\u004d\u0057.Rheingold.xVM.SLPAttrRply,System.String[])\u0042\u004d\u0057.Rheingold.CoreFramework.DatabaseProvider.VCIDevice",
-            ReplaceDeviceType) + module.PatchFunction(
+            version < new Version("4.60") ? ReplaceDeviceType : NormalizeDevType
+        ) + module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.xVM.SLP",
             "IsIcomUnsupported",
             "(System.Collections.Generic.Dictionary`2<System.String,System.String>)System.Boolean",
             DnlibUtils.ReturnFalseMethod);
+
+        if (result == 0)
+        {
+            Log.Warning("{PatchName} found no applicable target in {Assembly}({Version})", nameof(PatchSLP), module.Assembly.Name, version);
+        }
+
+        return result;
 
         static void ReplaceDeviceType(MethodDef method)
         {
@@ -997,6 +1014,53 @@ public static partial class PatchUtils
                     break;
                 }
             }
+        }
+
+        static void NormalizeDevType(MethodDef method)
+        {
+            const string parseAttrListOperand = "System.Collections.Generic.Dictionary`2<System.String,System.String> \u0042\u004d\u0057.Rheingold.xVM.SLP::ParseAttrList(\u0042\u004d\u0057.Rheingold.xVM.SLPString)";
+            var parseAttrListCall = method.FindInstruction(OpCodes.Call, parseAttrListOperand);
+            if (parseAttrListCall == null)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var instructions = method.Body.Instructions;
+            var idx = instructions.IndexOf(parseAttrListCall);
+            var stlocInstruction = instructions[idx + 1];
+            if (stlocInstruction.OpCode != OpCodes.Stloc_0)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var getItem = method.Module.Import(typeof(Dictionary<string, string>).GetMethod("get_Item"));
+            var setItem = method.Module.Import(typeof(Dictionary<string, string>).GetMethod("set_Item"));
+            var stringEquals = method.Module.Import(typeof(string).GetMethod("op_Equality", [typeof(string), typeof(string)]));
+
+            var insertionTarget = instructions[idx + 2];
+            Instruction[] normalizeDevType =
+            [
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Callvirt.ToInstruction(getItem),
+                OpCodes.Ldstr.ToInstruction("ICOM"),
+                OpCodes.Call.ToInstruction(stringEquals),
+                OpCodes.Brfalse_S.ToInstruction(insertionTarget),
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Ldstr.ToInstruction("ICOM-Next"),
+                OpCodes.Callvirt.ToInstruction(setItem),
+            ];
+
+            for (var i = 0; i < normalizeDevType.Length; i++)
+            {
+                instructions.Insert(idx + 2 + i, normalizeDevType[i]);
+            }
+
+            method.Body.SimplifyBranches();
+            method.Body.OptimizeBranches();
         }
     }
 

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -970,13 +970,6 @@ public static partial class PatchUtils
     {
         var version = module.Assembly.Version;
 
-        // < 4.60: SLP.cs still recognizes DevType=="ICOM" (legacy A/A2) directly; the device's
-        // DevTypeExt ("ICOM_A1"/"ICOM_A2") is what marks it unsupported, so hardcoding it to
-        // "ICOM_Next_A" is enough to route it through the ICOM-Next handling.
-        // >= 4.60: device dispatch was rewritten to only recognize DevType=="ICOM-Next"; legacy
-        // units report DevType=="ICOM" and now fall through to the ENET check, returning null
-        // (logged as "newDevice is null or invalid"). Normalize the parsed attribute dictionary
-        // right after it is built so the existing dispatch takes the ICOM-Next branch too.
         var result = module.PatchFunction(
             "\u0042\u004d\u0057.Rheingold.xVM.SLP",
             "ScanDeviceFromAttrList",
@@ -1019,27 +1012,40 @@ public static partial class PatchUtils
         static void NormalizeDevType(MethodDef method)
         {
             const string parseAttrListOperand = "System.Collections.Generic.Dictionary`2<System.String,System.String> \u0042\u004d\u0057.Rheingold.xVM.SLP::ParseAttrList(\u0042\u004d\u0057.Rheingold.xVM.SLPString)";
-            var parseAttrListCall = method.FindInstruction(OpCodes.Call, parseAttrListOperand);
-            if (parseAttrListCall == null)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
+            const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
+            const string opEqualityOperand = "System.Boolean System.String::op_Equality(System.String,System.String)";
 
             var instructions = method.Body.Instructions;
-            var idx = instructions.IndexOf(parseAttrListCall);
-            var stlocInstruction = instructions[idx + 1];
-            if (stlocInstruction.OpCode != OpCodes.Stloc_0)
+            var parseAttrListCall = method.FindInstruction(OpCodes.Call, parseAttrListOperand);
+            if (parseAttrListCall == null || instructions[instructions.IndexOf(parseAttrListCall) + 1].OpCode != OpCodes.Stloc_0)
             {
                 Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
-            var getItem = method.Module.Import(typeof(Dictionary<string, string>).GetMethod("get_Item"));
-            var setItem = method.Module.Import(typeof(Dictionary<string, string>).GetMethod("set_Item"));
-            var stringEquals = method.Module.Import(typeof(string).GetMethod("op_Equality", [typeof(string), typeof(string)]));
+            // Resolve the dictionary/string members from the TARGET module (mscorlib) by reusing existing
+            // operands. The patcher targets .NET (net10.0), so importing via typeof() binds them to
+            // System.Private.CoreLib, which does not exist on ISTA's .NET Framework runtime and breaks the
+            // patched method (only non-primitive types like Dictionary`2 are affected; dnlib remaps String).
+            var module = method.Module;
+            var getItem = method.FindInstruction(OpCodes.Callvirt, getItemOperand)?.Operand as IMethod;
+            var stringEquals = method.FindInstruction(OpCodes.Call, opEqualityOperand)?.Operand as IMethod;
+            if (getItem == null || stringEquals == null)
+            {
+                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+                return;
+            }
 
+            var setItemSig = MethodSig.CreateInstance(module.CorLibTypes.Void, new GenericVar(0), new GenericVar(1));
+            var setItem = new MemberRefUser(module, "set_Item", setItemSig, getItem.DeclaringType);
+
+            // >= 4.60: legacy ICOM/A1/A2 report DevType != "ICOM-Next" and fall through to the ENET check.
+            // Right after ParseAttrList, rewrite those to "ICOM-Next" so they take the existing ICOM-Next
+            // dispatch branch, and force DevTypeExt to "ICOM_Next_A". Genuine ICOM-Next is left untouched
+            // (its DevType never matches), so its dispatch, firmware check and State stay exactly as upstream.
+            var idx = instructions.IndexOf(parseAttrListCall);
             var insertionTarget = instructions[idx + 2];
+            var normalizeStart = OpCodes.Ldloc_0.ToInstruction();
             Instruction[] normalizeDevType =
             [
                 OpCodes.Ldloc_0.ToInstruction(),
@@ -1047,10 +1053,27 @@ public static partial class PatchUtils
                 OpCodes.Callvirt.ToInstruction(getItem),
                 OpCodes.Ldstr.ToInstruction("ICOM"),
                 OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brfalse_S.ToInstruction(insertionTarget),
+                OpCodes.Brtrue.ToInstruction(normalizeStart),
                 OpCodes.Ldloc_0.ToInstruction(),
                 OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Callvirt.ToInstruction(getItem),
+                OpCodes.Ldstr.ToInstruction("ICOM A1"),
+                OpCodes.Call.ToInstruction(stringEquals),
+                OpCodes.Brtrue.ToInstruction(normalizeStart),
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevType"),
+                OpCodes.Callvirt.ToInstruction(getItem),
+                OpCodes.Ldstr.ToInstruction("ICOM A2"),
+                OpCodes.Call.ToInstruction(stringEquals),
+                OpCodes.Brtrue.ToInstruction(normalizeStart),
+                OpCodes.Br.ToInstruction(insertionTarget),
+                normalizeStart,
+                OpCodes.Ldstr.ToInstruction("DevType"),
                 OpCodes.Ldstr.ToInstruction("ICOM-Next"),
+                OpCodes.Callvirt.ToInstruction(setItem),
+                OpCodes.Ldloc_0.ToInstruction(),
+                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
+                OpCodes.Ldstr.ToInstruction("ICOM_Next_A"),
                 OpCodes.Callvirt.ToInstruction(setItem),
             ];
 

--- a/src/ISTAlter/Core/PatchUtils.Optional.cs
+++ b/src/ISTAlter/Core/PatchUtils.Optional.cs
@@ -1012,142 +1012,160 @@ public static partial class PatchUtils
         static void RewriteIcomNextDispatch(MethodDef method)
         {
             const string parseAttrListOperand = "System.Collections.Generic.Dictionary`2<System.String,System.String> \u0042\u004d\u0057.Rheingold.xVM.SLP::ParseAttrList(\u0042\u004d\u0057.Rheingold.xVM.SLPString)";
-            const string opEqualityOperand = "System.Boolean System.String::op_Equality(System.String,System.String)";
-            const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
-            const string containsKeyOperand = "System.Boolean System.Collections.Generic.Dictionary`2<System.String,System.String>::ContainsKey(System.String)";
-
-            var instructions = method.Body.Instructions;
-
-            // Sanity anchor: ScanDeviceFromAttrList opens with dictionary = ParseAttrList(...).
             if (method.FindInstruction(OpCodes.Call, parseAttrListOperand) == null)
             {
                 Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
                 return;
             }
 
-            // Anchor: the DevType=="ICOM-Next" dispatch comparison (ldstr / call op_Equality / brfalse else).
-            var icomNext = method.FindInstruction(OpCodes.Ldstr, "ICOM-Next");
-            if (icomNext == null)
+            var widened = WidenIcomDispatch(method);
+            var gated = KeepRawStateForLegacyIcom(method);
+            if (widened || gated)
             {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
+                method.Body.SimplifyBranches();
+                method.Body.OptimizeBranches();
             }
-
-            var idxNext = instructions.IndexOf(icomNext);
-            var dispatchEquals = instructions[idxNext + 1];
-            var dispatchBranch = instructions[idxNext + 2];
-            if (dispatchEquals.OpCode != OpCodes.Call ||
-                !string.Equals((dispatchEquals.Operand as IMethod)?.FullName, opEqualityOperand, StringComparison.Ordinal) ||
-                (dispatchBranch.OpCode != OpCodes.Brfalse && dispatchBranch.OpCode != OpCodes.Brfalse_S) ||
-                dispatchBranch.Operand is not Instruction dispatchElseTarget)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            var dispatchBodyStart = instructions[idxNext + 3];
-
-            // Anchor: the State try block, whose try opens with "ICOM".Equals(vcidevice.DevType, ...).
-            var stateTry = method.Body.ExceptionHandlers.FirstOrDefault(eh =>
-                eh.TryStart?.OpCode == OpCodes.Ldstr && string.Equals(eh.TryStart.Operand as string, "ICOM", StringComparison.Ordinal));
-            var setState = instructions.FirstOrDefault(i => i.OpCode == OpCodes.Callvirt && string.Equals((i.Operand as IMethod)?.Name?.ToString(), "set_State", StringComparison.Ordinal))?.Operand as IMethod;
-            if (stateTry?.HandlerEnd is not { } leaveTarget || setState == null)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            var icomEquals = stateTry.TryStart;
-
-            var vciLoad = instructions[instructions.IndexOf(icomEquals) + 1];
-            var vciLocal = vciLoad.OpCode.Code switch
-            {
-                Code.Ldloc_0 => method.Body.Variables[0],
-                Code.Ldloc_1 => method.Body.Variables[1],
-                Code.Ldloc_2 => method.Body.Variables[2],
-                Code.Ldloc_3 => method.Body.Variables[3],
-                Code.Ldloc_S or Code.Ldloc => vciLoad.Operand as Local,
-                _ => null,
-            };
-            if (vciLocal == null)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            // Reuse the target module's (mscorlib) members straight from existing operands; never via typeof()
-            // (the net10.0 patcher would bind those to System.Private.CoreLib, absent on ISTA's .NET Framework
-            // runtime, breaking the patched method - dnlib remaps primitives like String but not Dictionary`2).
-            var getItem = method.FindInstruction(OpCodes.Callvirt, getItemOperand)?.Operand as IMethod;
-            var containsKey = method.FindInstruction(OpCodes.Callvirt, containsKeyOperand)?.Operand as IMethod;
-            var stringEquals = dispatchEquals.Operand as IMethod;
-            if (getItem == null || containsKey == null || stringEquals == null)
-            {
-                Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
-                return;
-            }
-
-            // Step 1: widen the dispatch so legacy DevType=="ICOM" also takes the ICOM-Next branch. Real legacy
-            // ICOM A/A1/A2 report DevType="ICOM" (the A1/A2 distinction lives in DevTypeExt); only ICOM-Next
-            // reports DevType="ICOM-Next". DevTypeExt is never rewritten.
-            dispatchBranch.OpCode = OpCodes.Brtrue;
-            dispatchBranch.Operand = dispatchBodyStart;
-            Instruction[] widenDispatch =
-            [
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevType"),
-                OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM"),
-                OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(dispatchBodyStart),
-                OpCodes.Br.ToInstruction(dispatchElseTarget),
-            ];
-            var widenAt = instructions.IndexOf(dispatchBranch) + 1;
-            for (var i = 0; i < widenDispatch.Length; i++)
-            {
-                instructions.Insert(widenAt + i, widenDispatch[i]);
-            }
-
-            // Step 2: keep the raw reported State for legacy A1/A2 only, identified by DevTypeExt
-            // ("ICOM_A1"/"ICOM_A2"). Genuine ICOM-Next ("ICOM_Next_A") and non-ICOM devices do not match and
-            // fall through to the original firmware/State logic, untouched.
-            var setStateRaw = OpCodes.Ldloc.ToInstruction(vciLocal);
-            Instruction[] stateGate =
-            [
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
-                OpCodes.Callvirt.ToInstruction(containsKey),
-                OpCodes.Brfalse.ToInstruction(icomEquals),
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
-                OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM_A1"),
-                OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brtrue.ToInstruction(setStateRaw),
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("DevTypeExt"),
-                OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Ldstr.ToInstruction("ICOM_A2"),
-                OpCodes.Call.ToInstruction(stringEquals),
-                OpCodes.Brfalse.ToInstruction(icomEquals),
-                setStateRaw,
-                OpCodes.Ldloc_0.ToInstruction(),
-                OpCodes.Ldstr.ToInstruction("State"),
-                OpCodes.Callvirt.ToInstruction(getItem),
-                OpCodes.Callvirt.ToInstruction(setState),
-                OpCodes.Leave.ToInstruction(leaveTarget),
-            ];
-            var gateAt = instructions.IndexOf(icomEquals);
-            for (var i = 0; i < stateGate.Length; i++)
-            {
-                instructions.Insert(gateAt + i, stateGate[i]);
-            }
-
-            stateTry.TryStart = stateGate[0];
-
-            method.Body.SimplifyBranches();
-            method.Body.OptimizeBranches();
         }
+    }
+
+    // >= 4.60: legacy ICOM (A/A1/A2) report DevType="ICOM" while ISTA only dispatches DevType=="ICOM-Next".
+    // Widen the dispatch so DevType=="ICOM" also takes the ICOM-Next branch (DevTypeExt is never rewritten).
+    private static bool WidenIcomDispatch(MethodDef method)
+    {
+        const string opEqualityOperand = "System.Boolean System.String::op_Equality(System.String,System.String)";
+        const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
+
+        var instructions = method.Body.Instructions;
+
+        // Anchor: the DevType=="ICOM-Next" dispatch comparison (ldstr / call op_Equality / brfalse else).
+        var icomNext = method.FindInstruction(OpCodes.Ldstr, "ICOM-Next");
+        if (icomNext == null)
+        {
+            Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+            return false;
+        }
+
+        var idxNext = instructions.IndexOf(icomNext);
+        var dispatchEquals = instructions[idxNext + 1];
+        var dispatchBranch = instructions[idxNext + 2];
+        if (dispatchEquals.OpCode != OpCodes.Call ||
+            !string.Equals((dispatchEquals.Operand as IMethod)?.FullName, opEqualityOperand, StringComparison.Ordinal) ||
+            (dispatchBranch.OpCode != OpCodes.Brfalse && dispatchBranch.OpCode != OpCodes.Brfalse_S) ||
+            dispatchBranch.Operand is not Instruction dispatchElseTarget)
+        {
+            Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+            return false;
+        }
+
+        var dispatchBodyStart = instructions[idxNext + 3];
+
+        // Reuse the target module's (mscorlib) members from existing operands; never via typeof() (the net
+        // patcher would bind those to System.Private.CoreLib, absent on ISTA's .NET Framework runtime).
+        var getItem = method.FindInstruction(OpCodes.Callvirt, getItemOperand)?.Operand as IMethod;
+        var stringEquals = dispatchEquals.Operand as IMethod;
+        if (getItem == null || stringEquals == null)
+        {
+            Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+            return false;
+        }
+
+        dispatchBranch.OpCode = OpCodes.Brtrue;
+        dispatchBranch.Operand = dispatchBodyStart;
+        Instruction[] widenDispatch =
+        [
+            OpCodes.Ldloc_0.ToInstruction(),
+            OpCodes.Ldstr.ToInstruction("DevType"),
+            OpCodes.Callvirt.ToInstruction(getItem),
+            OpCodes.Ldstr.ToInstruction("ICOM"),
+            OpCodes.Call.ToInstruction(stringEquals),
+            OpCodes.Brtrue.ToInstruction(dispatchBodyStart),
+            OpCodes.Br.ToInstruction(dispatchElseTarget),
+        ];
+        var widenAt = instructions.IndexOf(dispatchBranch) + 1;
+        for (var i = 0; i < widenDispatch.Length; i++)
+        {
+            instructions.Insert(widenAt + i, widenDispatch[i]);
+        }
+
+        return true;
+    }
+
+    // Keep the raw reported State for legacy ICOM A1/A2 only, identified by DevTypeExt ("ICOM_A1"/"ICOM_A2"),
+    // bypassing the firmware-update "14" downgrade. Genuine ICOM-Next ("ICOM_Next_A") and non-ICOM devices do
+    // not match and fall through to the original firmware/State logic, untouched.
+    private static bool KeepRawStateForLegacyIcom(MethodDef method)
+    {
+        const string opEqualityOperand = "System.Boolean System.String::op_Equality(System.String,System.String)";
+        const string getItemOperand = "System.String System.Collections.Generic.Dictionary`2<System.String,System.String>::get_Item(System.String)";
+        const string containsKeyOperand = "System.Boolean System.Collections.Generic.Dictionary`2<System.String,System.String>::ContainsKey(System.String)";
+
+        var instructions = method.Body.Instructions;
+
+        // The State try block opens with "ICOM".Equals(vcidevice.DevType, ...); match on the handler's TryStart
+        // (not the first "ICOM" ldstr, which is the vcidevice.DevType = "ICOM" assignment in the dispatch branch).
+        var stateTry = method.Body.ExceptionHandlers.FirstOrDefault(eh =>
+            eh.TryStart?.OpCode == OpCodes.Ldstr && string.Equals(eh.TryStart.Operand as string, "ICOM", StringComparison.Ordinal));
+        var setState = instructions.FirstOrDefault(i => i.OpCode == OpCodes.Callvirt && string.Equals((i.Operand as IMethod)?.Name?.ToString(), "set_State", StringComparison.Ordinal))?.Operand as IMethod;
+        if (stateTry?.HandlerEnd is not { } leaveTarget || setState == null)
+        {
+            Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+            return false;
+        }
+
+        var icomEquals = stateTry.TryStart;
+        var vciLoad = instructions[instructions.IndexOf(icomEquals) + 1];
+        var vciLocal = vciLoad.OpCode.Code switch
+        {
+            Code.Ldloc_0 => method.Body.Variables[0],
+            Code.Ldloc_1 => method.Body.Variables[1],
+            Code.Ldloc_2 => method.Body.Variables[2],
+            Code.Ldloc_3 => method.Body.Variables[3],
+            Code.Ldloc_S or Code.Ldloc => vciLoad.Operand as Local,
+            _ => null,
+        };
+        var getItem = method.FindInstruction(OpCodes.Callvirt, getItemOperand)?.Operand as IMethod;
+        var containsKey = method.FindInstruction(OpCodes.Callvirt, containsKeyOperand)?.Operand as IMethod;
+        var stringEquals = method.FindInstruction(OpCodes.Call, opEqualityOperand)?.Operand as IMethod;
+        if (vciLocal == null || getItem == null || containsKey == null || stringEquals == null)
+        {
+            Log.Warning("Required instructions not found, can not patch {Method}", method.FullName);
+            return false;
+        }
+
+        var setStateRaw = OpCodes.Ldloc.ToInstruction(vciLocal);
+        Instruction[] stateGate =
+        [
+            OpCodes.Ldloc_0.ToInstruction(),
+            OpCodes.Ldstr.ToInstruction("DevTypeExt"),
+            OpCodes.Callvirt.ToInstruction(containsKey),
+            OpCodes.Brfalse.ToInstruction(icomEquals),
+            OpCodes.Ldloc_0.ToInstruction(),
+            OpCodes.Ldstr.ToInstruction("DevTypeExt"),
+            OpCodes.Callvirt.ToInstruction(getItem),
+            OpCodes.Ldstr.ToInstruction("ICOM_A1"),
+            OpCodes.Call.ToInstruction(stringEquals),
+            OpCodes.Brtrue.ToInstruction(setStateRaw),
+            OpCodes.Ldloc_0.ToInstruction(),
+            OpCodes.Ldstr.ToInstruction("DevTypeExt"),
+            OpCodes.Callvirt.ToInstruction(getItem),
+            OpCodes.Ldstr.ToInstruction("ICOM_A2"),
+            OpCodes.Call.ToInstruction(stringEquals),
+            OpCodes.Brfalse.ToInstruction(icomEquals),
+            setStateRaw,
+            OpCodes.Ldloc_0.ToInstruction(),
+            OpCodes.Ldstr.ToInstruction("State"),
+            OpCodes.Callvirt.ToInstruction(getItem),
+            OpCodes.Callvirt.ToInstruction(setState),
+            OpCodes.Leave.ToInstruction(leaveTarget),
+        ];
+        var gateAt = instructions.IndexOf(icomEquals);
+        for (var i = 0; i < stateGate.Length; i++)
+        {
+            instructions.Insert(gateAt + i, stateGate[i]);
+        }
+
+        stateTry.TryStart = stateGate[0];
+        return true;
     }
 
     [MotorbikeClamp15Patch]


### PR DESCRIPTION
## Summary

ISTA **4.60** rewrote the SLP device dispatch in `SLP.ScanDeviceFromAttrList` (`RheingoldxVM.dll`) to only recognize `DevType == "ICOM-Next"`. Legacy ICOM units (ICOM-A / A1 / A2) report `DevType == "ICOM"` (with `DevTypeExt == "ICOM_A1"` / `"ICOM_A2"`), so on 4.60+ they fall through to the ENET check and `ScanDeviceFromAttrList` returns `null` → the VCI is never listed. Even when forced through, they are flagged unsupported / firmware-update-required and end up in device State `"14"` / `"15"` ("Firmware"), which blocks the connection.

This PR extends `PatchSLP` so legacy ICOM boxes are recognized and usable on **4.60+**, while leaving genuine ICOM-Next behavior strictly upstream.

## What changed (`PatchUtils.PatchSLP`, path `>= 4.60`)

1. **Dispatch widening** — accept `DevType == "ICOM"` in addition to `"ICOM-Next"`, so legacy units take the existing ICOM-Next branch.
2. **State gate (A1/A2 only)** — keep the raw reported State when `DevTypeExt` is `"ICOM_A1"` / `"ICOM_A2"`, bypassing the firmware-update `"14"` downgrade. `DevTypeExt` is **never rewritten**, so the A1/A2 identity is preserved.
3. **`IsIcomUnsupported → false`** (unchanged from before) — prevents the unsupported-path blanking of IP/VIN/VciChannels and the `"15"` State for A1/A2.

Genuine **ICOM-Next** (`DevType="ICOM-Next"`, `DevTypeExt="ICOM_Next_A"`) does not match the A1/A2 gate, so its dispatch, firmware check and State remain exactly as upstream.

Versions **< 4.60** keep the original `ReplaceDeviceType` path, untouched.

| Device | `DevType` | `DevTypeExt` | Result |
|---|---|---|---|
| ICOM-Next | `ICOM-Next` | `ICOM_Next_A` | unchanged / upstream |
| Legacy ICOM A1/A2 | `ICOM` | `ICOM_A1` / `ICOM_A2` | detected + raw State (no "Firmware" block) |
