### PR TITLE
fix: scope the ENET real-ECU voltage-check patch to the diagnostic module loader only

### DIFF
--- a/src/ISTAlter/Core/PatchUtils.ISTAVoltage.cs
+++ b/src/ISTAlter/Core/PatchUtils.ISTAVoltage.cs
@@ -222,6 +222,8 @@ public static partial class PatchUtils
     /// read different sources.
     /// </para>
     /// </remarks>
+    /// <param name="module">The <see cref="ModuleDefMD"/> (RheingoldSessionController.dll) to apply the patch to.</param>
+    /// <returns>The number of methods patched (0 or 1).</returns>
     [ISTAVoltagePatch]
     [LibraryName("RheingoldSessionController.dll")]
     public static int PatchModuleBootstrapLoaderEthernetVoltageCheck(ModuleDefMD module)

--- a/src/ISTAlter/Core/PatchUtils.ISTAVoltage.cs
+++ b/src/ISTAlter/Core/PatchUtils.ISTAVoltage.cs
@@ -182,4 +182,100 @@ public static partial class PatchUtils
             method.Body.OptimizeBranches();
         }
     }
+
+    /// <summary>
+    /// Skips the ENET real-ECU voltage check (<c>VoltageUtils.CheckVoltageForEthernetConnection</c>)
+    /// specifically inside <c>ModuleBootstrapLoader.doIt()</c> (RheingoldSessionController.dll) --
+    /// the diagnostic test-module execution loop -- without touching <c>VoltageUtils</c> itself or
+    /// any other caller.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="PatchISTAVoltageControl"/> only makes ISTA's VCI-side voltage checks (the ones
+    /// reading <c>VCI.Kl15Voltage</c>/<c>Kl30Voltage</c>, i.e. <c>ProgrammingUtils.CheckClamp30</c>
+    /// and <c>SessionLogic.CheckClamp30</c>) pass, because the injected DLL writes into that exact
+    /// field. On an ENET connection, ISTA has a THIRD, independent low-voltage check that never
+    /// reads that field: <c>VoltageUtils.CheckVoltageForEthernetConnection</c> runs a real
+    /// diagnostic service program on the vehicle's ECU (output parameter <c>"Batteriespannung"</c>)
+    /// and classifies the result against the same #120/#121/#122/#123/#127 thresholds. No value
+    /// written to the VCI can influence it -- it is a genuine ECU read.
+    /// </para>
+    /// <para>
+    /// <c>CheckVoltageForEthernetConnection</c> has three independent callers:
+    /// <c>ModuleBootstrapLoader.doIt()</c> (via <c>ModuleImpl</c>, BMW's *diagnostic* test-module
+    /// runner -- fires on every module load), <c>Logic.DoInitialElectricalChecks()</c> (one-shot at
+    /// connection), and a Toyota-only call inside
+    /// <c>ProgrammingUtils.CheckVehicleProgramingProhibits</c> (a programming-plan gate). This patch
+    /// touches only the first one: it changes the
+    /// <c>if (ModuleLoader.IsModuleLoaderInitialized &amp;&amp; ...)</c> guard around the call in
+    /// <c>doIt()</c> so it never enters the guarded block, by turning the leading (short-circuit)
+    /// branch on <c>ModuleLoader.IsModuleLoaderInitialized</c> into an unconditional jump to the same
+    /// target the false-case already used. <c>Logic.DoInitialElectricalChecks()</c> and the Toyota
+    /// programming-plan gate are left fully intact -- this patch never touches anything reachable
+    /// from a coding/flashing session.
+    /// </para>
+    /// <para>
+    /// Still diagnostic-scope only, not a substitute for a real external power supply: an ENET
+    /// session backed only by a battery and a faked VCI voltage can otherwise show a genuine
+    /// "battery voltage (terminal 30) below threshold value" message during plain fault-code/live-data
+    /// reading, even while the ISTA header displays a healthy injected value, because the two checks
+    /// read different sources.
+    /// </para>
+    /// </remarks>
+    [ISTAVoltagePatch]
+    [LibraryName("RheingoldSessionController.dll")]
+    public static int PatchModuleBootstrapLoaderEthernetVoltageCheck(ModuleDefMD module)
+    {
+        return module.PatchFunction(
+            "\u0042\u004d\u0057.Rheingold.Module.ISTA.ModuleBootstrapLoader",
+            "doIt",
+            "()\u0042\u004d\u0057.Rheingold.CoreFramework.IResult",
+            SkipEthernetVoltageCheck
+        );
+
+        static void SkipEthernetVoltageCheck(MethodDef method)
+        {
+            var instructions = method.Body.Instructions;
+
+            var isModuleLoaderInitializedCall = instructions.FirstOrDefault(i =>
+                i.OpCode == OpCodes.Call && i.Operand is IMethod m && m.Name == "get_IsModuleLoaderInitialized");
+            if (isModuleLoaderInitializedCall == null)
+            {
+                Log.Warning("get_IsModuleLoaderInitialized call not found, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var callIndex = instructions.IndexOf(isModuleLoaderInitializedCall);
+            if (callIndex < 0 || callIndex + 1 >= instructions.Count)
+            {
+                Log.Warning("Unexpected doIt layout, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var branch = instructions[callIndex + 1];
+            if (branch.OpCode == OpCodes.Pop)
+            {
+                return; // already patched (idempotent)
+            }
+
+            if (branch.OpCode != OpCodes.Brfalse && branch.OpCode != OpCodes.Brfalse_S)
+            {
+                Log.Warning("Unexpected branch after get_IsModuleLoaderInitialized, can not patch {Method}", method.FullName);
+                return;
+            }
+
+            var target = (Instruction)branch.Operand;
+
+            // Short-circuit &&: this branch already jumps straight past the whole guarded block (the
+            // ENET voltage check call, plus everything else the block gates) when
+            // IsModuleLoaderInitialized is false. Consume the bool the call just pushed and always
+            // take that same path, regardless of the real flag value.
+            branch.OpCode = OpCodes.Pop;
+            branch.Operand = null;
+            instructions.Insert(callIndex + 2, OpCodes.Br.ToInstruction(target));
+
+            method.Body.SimplifyBranches();
+            method.Body.OptimizeBranches();
+        }
+    }
 }


### PR DESCRIPTION
`VoltageUtils.CheckVoltageForEthernetConnection` (RheingoldProgramming.dll) reads the
vehicle's battery voltage via an ECU service program ("Batteriespannung") on ENET
connections. This read is independent of `VCI.Kl15Voltage`/`Kl30Voltage`.

This method has exactly three callers, confirmed by an exhaustive reference search of
the decompiled ISTA source tree:

1. `ModuleBootstrapLoader.doIt()` (RheingoldSessionController.dll,
   `BMW.Rheingold.Module.ISTA`) â invoked once per diagnostic test-module load.
2. `Logic.DoInitialElectricalChecks()` (RheingoldSessionController.dll) â invoked once
   at connection setup.
3. `ProgrammingUtils.CheckVehicleProgramingProhibits` (RheingoldProgramming.dll) â
   Toyota-only branch.

This patch modifies caller 1 only. Inside `ModuleBootstrapLoader.doIt()`, the leading
branch of the `if (ModuleLoader.IsModuleLoaderInitialized && ...)` guard around the
call is turned into an unconditional jump to the same target the false case already
used, so the guarded block is skipped every time, regardless of
`IsModuleLoaderInitialized`'s actual value.

Callers 2 and 3 are unmodified: no line of `Logic.cs` or `ProgrammingUtils.cs` is
touched by this patch.

`ProgrammingUtils.CheckClamp30` â the check that runs at every programming-plan launch
(`TherapyPlanExecutionRunner` â `CheckVehicleProgramingProhibits`) and reads
`VCI.Kl30Voltage` â is a separate function, not modified by this patch. A reference
search of `RheingoldProgramming.dll` (the assembly containing the programming/flashing
execution engine) shows zero references to `ModuleBootstrapLoader`,
`ModuleImpl`, or `ModuleLoader`. `ModuleBootstrapLoader.doIt()` is not invoked by the
programming/flashing execution path.
